### PR TITLE
Backport fix for plistlib API change

### DIFF
--- a/testing/mozbase/mozinstall/mozinstall/mozinstall.py
+++ b/testing/mozbase/mozinstall/mozinstall/mozinstall.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, print_function
 
 from optparse import OptionParser
 import os
+import plistlib
 import shutil
 import subprocess
 import sys
@@ -26,9 +27,6 @@ try:
     has_pefile = True
 except ImportError:
     has_pefile = False
-
-if mozinfo.isMac:
-    from plistlib import readPlist
 
 
 TIMEOUT_UNINSTALL = 60
@@ -72,8 +70,10 @@ def get_binary(path, app_name):
         if not os.path.isfile(plist):
             raise InvalidBinary('%s/Contents/Info.plist not found' % path)
 
-        binary = os.path.join(path, 'Contents/MacOS/',
-                              readPlist(plist)['CFBundleExecutable'])
+        with open(plist, "rb") as fp:
+            binary = os.path.join(
+                path, "Contents/MacOS/", plistlib.load(fp)["CFBundleExecutable"]
+            )
 
     else:
         app_name = app_name.lower()


### PR DESCRIPTION
Original: https://hg.mozilla.org/integration/autoland/diff/9f3d1f4e24e26a6b5f0db959fefe7608f80f9bf4/testing/mozbase/mozinstall/mozinstall/mozinstall.py