### PR TITLE
mozconfig should use rr-opt not wr-opt

### DIFF
--- a/mozconfig.macsample
+++ b/mozconfig.macsample
@@ -1,6 +1,6 @@
 . $topsrcdir/browser/config/mozconfig
 
-mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/wr-opt
+mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/rr-opt
 mk_add_options MOZ_MAKE_FLAGS="-j12"
 mk_add_options AUTOCLOBBER=1
 mk_add_options RECORD_REPLAY_NO_UPDATE=1

--- a/mozconfig.sample
+++ b/mozconfig.sample
@@ -1,6 +1,6 @@
 . $topsrcdir/browser/config/mozconfig
 
-mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/wr-opt
+mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/rr-opt
 mk_add_options MOZ_MAKE_FLAGS="-j12"
 mk_add_options AUTOCLOBBER=1
 mk_add_options RECORD_REPLAY_NO_UPDATE=1


### PR DESCRIPTION
There was a discrepancy between the `mozconfig` samples and the backend README. The backend README said to look for the builds in the `rr-opt` directory, but the `mozconfig` samples were setting the `MOZ_OBJDIR` to `wr-opt`. This change makes gecko-dev consistent with the backend README instructions.