### PR TITLE
Fix save recording race condition

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -10,7 +10,9 @@ const { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );
 const { OS } = ChromeUtils.import("resource://gre/modules/osfile.jsm");
-const { setTimeout } = Components.utils.import('resource://gre/modules/Timer.jsm');
+const { setTimeout } = Components.utils.import(
+  "resource://gre/modules/Timer.jsm"
+);
 
 XPCOMUtils.defineLazyModuleGetters(this, {
   AppUpdater: "resource:///modules/AppUpdater.jsm",
@@ -232,6 +234,7 @@ Services.ppmm.addMessageListener("RecordingFinished", {
       authId: getLoggedInUserAuthId(),
       recordingData: msg.data,
     });
+    Services.cpmm.sendAsyncMessage("RecordingSaved", msg.data);
   },
 });
 

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1738,7 +1738,9 @@ function reloadAndRecordTab(gBrowser) {
   }
 
   // Don't preprocess recordings if we will be submitting them for testing.
-  if (Services.prefs.getBoolPref("devtools.recordreplay.submitTestRecordings")) {
+  if (
+    Services.prefs.getBoolPref("devtools.recordreplay.submitTestRecordings")
+  ) {
     env.set("RECORD_REPLAY_DONT_PROCESS_RECORDINGS", "1");
   }
 
@@ -1773,7 +1775,7 @@ function reloadAndRecordTab(gBrowser) {
 
 let gFinishedRecordingWaiter;
 
-Services.ppmm.addMessageListener("RecordingFinished", {
+Services.ppmm.addMessageListener("RecordingSaved", {
   async receiveMessage(msg) {
     if (gFinishedRecordingWaiter) {
       gFinishedRecordingWaiter(msg.data);
@@ -1821,7 +1823,9 @@ async function reloadAndStopRecordingTab(gBrowser) {
   // When the submitTestRecordings pref is set we don't load the viewer,
   // but show a simple page that the recording was submitted, to make things
   // simpler for QA and provide feedback that the pref was set correctly.
-  if (Services.prefs.getBoolPref("devtools.recordreplay.submitTestRecordings")) {
+  if (
+    Services.prefs.getBoolPref("devtools.recordreplay.submitTestRecordings")
+  ) {
     const url = gBrowser.currentURI.spec;
     fetch(`https://test-inbox.replay.io/${recordingId}:${url}`);
     const why = `Test recording added: ${recordingId}`;
@@ -1919,6 +1923,9 @@ function viewRecordings() {
 function isAuthenticationEnabled() {
   // Authentication is controlled by a preference but can be disabled by an
   // environment variable.
-  return Services.prefs.getBoolPref("devtools.recordreplay.authentication-enabled")
-      && !env.get("RECORD_REPLAY_DISABLE_AUTHENTICATION");
+  return (
+    Services.prefs.getBoolPref(
+      "devtools.recordreplay.authentication-enabled"
+    ) && !env.get("RECORD_REPLAY_DISABLE_AUTHENTICATION")
+  );
 }


### PR DESCRIPTION
Prior to this change we had two listeners listening on the RecordingFinished
event. One that told the user that their recording was ready to view and
another that told the dispatcher about the metadata for that recording
which in turn stores that metadata in Hasura.

These listeners could get triggered in any order.

In devtools we check hasura to see if a user has permission to view a
recording when they go to view it. If the recording doesn't exist in
hasura we assume they don't.

Because the listeners could run out of order it seems possible that
the user could be redirected to the view recording page before
the dispatcher had stored the metadata for that recording in hasura,
resulting in the user getting an unauthorized error.

To fix this, rather than have the code structured like this:
```
                    +------>gFinishedRecordingWaiter
+-------------------+
| RecordingFinished |
+-------------------+
                    +------>setRecordingMetadata
```
We structure it like this:
```
+-----------------+                           +--------------+
|RecordingFinished+-->setRecordingMetadata+-->+RecordingSaved+-->gFinishedRecordingWaiter
+-----------------+                           +--------------+
```
So that the events fire in a strict sequence, and the user is only
redirected to the view page _after_ the recording metadata has been
saved in hasura.

Fixes RecordReplay/devtools#1039