### PR TITLE
Ensure that resources exist before they go in a recording.

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -184,15 +184,15 @@ async function addRecordingResource(recordingId, url) {
     const text = await response.text();
     const resource = getResourceInfo(url, text);
 
-    await sendCommand("Internal.addRecordingResource", {
-      recordingId,
-      resource,
-    });
-
     const { known } = await sendCommand("Internal.hasResource", { resource });
     if (!known) {
       await sendCommand("Internal.addResource", { resource, contents: text });
     }
+
+    await sendCommand("Internal.addRecordingResource", {
+      recordingId,
+      resource,
+    });
 
     return text;
   } catch (e) {


### PR DESCRIPTION
Seems like `addRecordingResource` should throw if you try to add a resource that doesn't exists, so we should do these in this order so the API can validate more.