### PR TITLE
devtools: always send authId along with all messages to dispatcher

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -133,6 +133,7 @@ const gRecordings = new Map();
 let gNextMessageId = 1;
 
 function sendCommand(method, params = {}) {
+  params["authId"] = getLoggedInUserAuthId();
   const id = gNextMessageId++;
   gWorker.postMessage({
     kind: "sendCommand",


### PR DESCRIPTION
This will be useful for observability/reliability work since we will be able to tie any user request to the dispatcher back to a userId by looking the user up by authId.