### PR TITLE
Associate a Recording object with each active recording process.

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -21,6 +21,8 @@ addDebuggerToGlobal(this);
 );
 const { Debugger, RecordReplayControl, Services, InspectorUtils } = sandbox;
 
+Services.cpmm.sendAsyncMessage("RecordingStarting");
+
 // This script can be loaded into non-recording/replaying processes during automated tests.
 // In non-recording/replaying processes there are no properties on RecordReplayControl.
 const isRecordingOrReplaying = !!RecordReplayControl.progressCounter;


### PR DESCRIPTION
This is just the first step and I'll likely be tweaking it more since I don't love the event emitter stuff, but I figured this is enough to at least validate the direction and is closest to the logic already there. `msg.target` is a message manager object in the parent process that is tied specifically to the child process that is sending the messages, so we can use that instance to represent the recording process and commicate with it, without worrying about multiple active recordings stepping in top of eachother, or needing to manually assign ID numbers to the child processes or something. It also means that all of the ppmm listener logic is confined to `connection.js` which I love.

With this logic in place, we can cleanly run `updateBrowserRemoteness` and await `onRecordingStarted` and cleanly associate the browser object with a specific new `Recording` instance, and use that to interact with the active recording.