### PR TITLE
Tie recording-stop handling to the recording itself

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -170,6 +170,10 @@ class Recording extends EventEmitter {
     });
   }
 
+  get osPid() {
+    return this._pmm.osPid;
+  }
+
   _onNewSourcemap({ recordingId, url, sourceMapURL }) {
     this._resourceUploads.push(uploadAllSourcemapAssets(recordingId, url, sourceMapURL));
   }


### PR DESCRIPTION
Main things here:
* We look up the browser object based on the pid of the recording
* We use `browser` objects instead of `gBrowser` so we're much more consistent about which tab we're working with

Fixes #216, Fixes #199