### PR TITLE
Restart recording properly when refreshing.

### DIFF
--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -3674,7 +3674,7 @@ function BrowserReloadWithFlags(reloadFlags) {
       // Recording tabs always use new content processes when reloading, to get
       // a fresh recording.
       gBrowser.updateBrowserRemoteness(browser, {
-        recordExecution: "*",
+        recordExecution: browser.getAttribute("recordExecution"),
         newFrameloader: true,
         remoteType: E10SUtils.DEFAULT_REMOTE_TYPE,
       });

--- a/browser/base/content/utilityOverlay.js
+++ b/browser/base/content/utilityOverlay.js
@@ -640,7 +640,7 @@ function openLinkIn(url, where, params) {
         targetBrowser.currentURI.spec != "about:blank"
       ) {
         w.gBrowser.updateBrowserRemoteness(targetBrowser, {
-          recordExecution: "*",
+          recordExecution: browser.getAttribute("recordExecution"),
           newFrameloader: true,
           remoteType: E10SUtils.DEFAULT_REMOTE_TYPE,
         });

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1783,11 +1783,13 @@ function getBrowserForPid(pid) {
 
 function onRecordingStarted(recording) {
   const triggeringPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
-  let browser = getBrowserForPid(recording.osPid);
+  // There can occasionally be times when the browser isn't found when the
+  // recording begins, so we lazily look it up the first time it is needed.
+  let browser = null;
   function getBrowser() {
     // If the browser tab is moved to a new window, the cached browser object isn't
     // valid anymore so we need to find the new one.
-    if (!browser.getTabBrowser()) {
+    if (!browser || !browser.getTabBrowser()) {
       browser = getBrowserForPid(recording.osPid)
     }
     return browser;


### PR DESCRIPTION
Looks like this is just fixing behavior that was there before so nothing too complicated. In testing, I got an exception from my `getBrowserForPid` function, so I guess there's at least a bit of a race between `remoteTab` being created, and the `RecordingStarted` message from the child process.

Fixes #205 