### PR TITLE
Fix broken back button after recording.

### DIFF
--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1812,10 +1812,10 @@ function onRecordingStarted(recording) {
     getBrowser().loadURI(`about:replay?error=${why}`, { triggeringPrincipal });
   });
   recording.on("finished", function() {
-    clearRecordingState();
+    oldURL = getBrowser().currentURI.spec;
+    urlLoadOpts = { triggeringPrincipal, oldRecordedURL: oldURL };
 
-    oldURL = getBrowser().currentURI.spec
-    urlLoadOpts = { triggeringPrincipal, oldRecordedURL: oldURL }
+    clearRecordingState();
 
     // The recording has finished, so we need to navigate somewhere or else
     // the user will be shown the tab-crash page while we wait for the recording


### PR DESCRIPTION
I broke this in the refactoring in #231. I guess `updateBrowserRemoteness` must cause `currentURI` to be cleared, woops.