### PR TITLE
Rely on Gecko to tell us when something is inline.

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -262,11 +262,7 @@ gDebugger.onNewScript = (script) => {
   }
 
   let kind = "scriptSource";
-
-  // This test is pretty lame but the "scriptElement" introduction type doesn't
-  // distinguish between script elements with inline content and with a "src"
-  // attribute.
-  if (script.source.url.endsWith("html")) {
+  if (script.source.introductionType === "inlineScript") {
     kind = "inlineScript";
   }
 


### PR DESCRIPTION
Now that we've pulled the new gecko-dev, this comment no longer applies. I fixed this in https://bugzilla.mozilla.org/show_bug.cgi?id=1643540 