### PR TITLE
Updated Readme as  mozconfig.sample is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ the Record Replay gecko based browser.
 6. run `./mach build`
 7. run `./mach run`
 
-**Other OS**
+**Linux**
 
-1. `cp mozconfig.sample mozconfig`
+1. `cp mozconfig.linuxsample`
 2. run `./mach bootstrap` and select (2) Firefox Desktop
 3. run `./mach build`
 4. run `./mach run`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the Record Replay gecko based browser.
 
 **Linux**
 
-1. `cp mozconfig.linuxsample`
+1. `cp mozconfig.linuxsample mozconfig`
 2. run `./mach bootstrap` and select (2) Firefox Desktop
 3. run `./mach build`
 4. run `./mach run`


### PR DESCRIPTION
I tried to build but found that the mozconfig.sample file is not in the project anymore. I found that there were recent changes that introduced mozconfig.macsample instead. So, I update the readme to include Linux steps instead of Other OS. Not sure if this is a reasonable update. 