### PR TITLE
Add URL parameters to the sign in button link

### DIFF
--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1514,7 +1514,7 @@ function createRecordingButton() {
     onClick(evt) {
       const { gBrowser } = evt.target.ownerDocument.defaultView;
       const triggeringPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
-      gBrowser.loadURI("https://replay.io/view", { triggeringPrincipal });
+      gBrowser.loadURI("https://replay.io/view?forceOpenAuth=true", { triggeringPrincipal });
     },
     onCreated(node) {
       node.refreshStatus = () => {

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1514,7 +1514,7 @@ function createRecordingButton() {
     onClick(evt) {
       const { gBrowser } = evt.target.ownerDocument.defaultView;
       const triggeringPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
-      gBrowser.loadURI("https://replay.io/view?forceOpenAuth=true", { triggeringPrincipal });
+      gBrowser.loadURI("https://replay.io/view?signin=true", { triggeringPrincipal });
     },
     onCreated(node) {
       node.refreshStatus = () => {


### PR DESCRIPTION
The new URL parameters will be read by the frontend and will automatically redirect the user to the Auth0 login page. Corresponding PR [here](https://github.com/RecordReplay/devtools/pull/1635).

Fixes #276.