### PR TITLE
build: change update server

### DIFF
--- a/build/moz.build
+++ b/build/moz.build
@@ -84,7 +84,7 @@ if CONFIG["MOZ_APP_BASENAME"]:
         if CONFIG[var]:
             appini_defines[var] = True
 
-    appini_defines["MOZ_APPUPDATE_HOST"] = "updates.replay.io:8003"
+    appini_defines["MOZ_APPUPDATE_HOST"] = "updates-k8s.replay.io"
     if CONFIG["MOZ_APPUPDATE_HOST"]:
         appini_defines["MOZ_APPUPDATE_HOST"] = CONFIG["MOZ_APPUPDATE_HOST"]
 


### PR DESCRIPTION
We're migrating all servers in to k8s. As part of doing that I'd like to
change the port that the update server listens on so we don't have to poke
more holes in the AWS security group.

But if I just changed the port and released a new browser then old clients
wouldn't get the new update since they'd be pointed at the old server.
To get around this I created a new DNS entry, `update-k8s` that points to
the new update server running k8s.

Once a new browser is released we can wait a while, turn off the old non-
k8s update server, and change update server URL back to `updates.replay.io`
which will point to k8s.