### PR TITLE
Suppress about:newinstall for replay

### DIFF
--- a/browser/components/BrowserContentHandler.jsm
+++ b/browser/components/BrowserContentHandler.jsm
@@ -238,12 +238,16 @@ function openBrowserWindow(
       Ci.nsIToolkitProfileService
     );
     if (isStartup && pService.createdAlternateProfile) {
-      let url = NEWINSTALL_PAGE;
-      if (Array.isArray(urlOrUrlList)) {
-        urlOrUrlList.unshift(url);
-      } else {
-        urlOrUrlList = [url, urlOrUrlList];
-      }
+      // Suppress showing about:newinstall for profiles for Replay which
+      // may be installed next to other versions of Firefox and _should_
+      // use a new profile
+
+      // let url = NEWINSTALL_PAGE;
+      // if (Array.isArray(urlOrUrlList)) {
+      //   urlOrUrlList.unshift(url);
+      // } else {
+      //   urlOrUrlList = [url, urlOrUrlList];
+      // }
     }
 
     if (Array.isArray(urlOrUrlList)) {
@@ -654,7 +658,11 @@ nsBrowserContentHandler.prototype = {
             // Override the welcome page to explain why the user has a new
             // profile. nsBrowserGlue.css will be responsible for showing the
             // modal dialog.
-            overridePage = NEWINSTALL_PAGE;
+
+            // Suppress showing about:newinstall for profiles for Replay which
+            // may be installed next to other versions of Firefox and _should_
+            // use a new profile
+            // overridePage = NEWINSTALL_PAGE;
             break;
           case OVERRIDE_NEW_PROFILE:
             // New profile.

--- a/browser/components/BrowserGlue.jsm
+++ b/browser/components/BrowserGlue.jsm
@@ -2375,7 +2375,9 @@ BrowserGlue.prototype = {
       Ci.nsIToolkitProfileService
     );
     if (pService.createdAlternateProfile) {
-      this._showNewInstallModal();
+      // Suppress showing modal for profiles for Replay which may be installed
+      // next to other versions of Firefox and _should_ use a new profile
+      // this._showNewInstallModal();
     }
 
     FirefoxMonitor.init();


### PR DESCRIPTION
Suppresses the dialog and home page overrides that warn the user that a new profile was created. This seems to be only triggered when Replay is first launched on a system with a prior conflicting version of Firefox. I'm not sure if Replay would need this capability in the future so commenting out these side-effects of `pService.createdAlternateProfile` seemed like the safest approach.

Fixes #288