### PR TITLE
Add hook to inject replay-specific globals

### DIFF
--- a/devtools/server/actors/replay/globals.js
+++ b/devtools/server/actors/replay/globals.js
@@ -1,0 +1,8 @@
+// Uses the debugger interface to inject members into new global objects (like `window`)
+Components.utils.import('resource://gre/modules/jsdebugger.jsm');
+addDebuggerToGlobal(globalThis);
+
+const dbg = new Debugger();
+dbg.onNewGlobalObject = g => {
+	g.setProperty('__IS_RECORD_REPLAY_RUNTIME__', true);
+};

--- a/devtools/server/actors/replay/moz.build
+++ b/devtools/server/actors/replay/moz.build
@@ -11,6 +11,7 @@ DIRS += [
 DevToolsModules(
     'connection-worker.js',
     'connection.js',
+    'globals.js',
     'module.js',
 )
 

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1886,6 +1886,8 @@ Services.obs.addObserver(
   "recordreplay-recording-started"
 );
 
+Services.ppmm.loadProcessScript("resource://devtools/server/actors/replay/globals.js", true);
+
 function getViewURL() {
   let viewHost = "https://replay.io";
 


### PR DESCRIPTION
Adds a new script, `globals.js`, which uses the `Debugger` interface to inject members into new globals.

Fixes #343 