### PR TITLE
Improve replay branding in about:preferences

### DIFF
--- a/browser/branding/recordreplay/pref/firefox-branding.js
+++ b/browser/branding/recordreplay/pref/firefox-branding.js
@@ -18,6 +18,9 @@ pref("app.update.url.manual", "https://replay.io");
 // supplied in the "An update is available" page of the update wizard.
 pref("app.update.url.details", "https://replay.io");
 
+// Adding a trailing # to support appending targeted help from "Learn more" links
+pref('replay.support.baseURL', 'https://www.notion.so/Replay-Docs-56758667f53a4d51b7c6fc7a641adb02#');
+
 // The number of days a binary is permitted to be old
 // without checking for an update.  This assumes that
 // app.update.checkInstallTime is true.

--- a/browser/components/preferences/findInPage.js
+++ b/browser/components/preferences/findInPage.js
@@ -51,8 +51,9 @@ var gSearchResultsPane = {
       // Initialize other panes in an idle callback.
       window.requestIdleCallback(() => this.initializeCategories());
     }
+    // [REPLAY] Redirect support links to replay docs
     let helpUrl =
-      Services.urlFormatter.formatURLPref("app.support.baseURL") +
+      Services.urlFormatter.formatURLPref("replay.support.baseURL") +
       "preferences";
     let helpContainer = document.getElementById("need-help");
     helpContainer.querySelector("a").href = helpUrl;

--- a/browser/components/preferences/preferences.js
+++ b/browser/components/preferences/preferences.js
@@ -114,7 +114,7 @@ function init_all() {
   Preferences.forceEnableInstantApply();
 
   register_module("paneGeneral", gMainPane);
-  register_module("paneHome", gHomePane);
+  // register_module("paneHome", gHomePane);
   register_module("paneSearch", gSearchPane);
   register_module("panePrivacy", gPrivacyPane);
   register_module("paneContainers", gContainersPane);
@@ -157,8 +157,9 @@ function init_all() {
 
   gotoPref().then(() => {
     let helpButton = document.getElementById("helpButton");
+    // [REPLAY] Redirect support links to replay docs
     let helpUrl =
-      Services.urlFormatter.formatURLPref("app.support.baseURL") +
+      Services.urlFormatter.formatURLPref("replay.support.baseURL") +
       "preferences";
     helpButton.setAttribute("href", helpUrl);
 

--- a/browser/components/preferences/preferences.xhtml
+++ b/browser/components/preferences/preferences.xhtml
@@ -89,7 +89,7 @@
         </richlistitem>
 
         <richlistitem id="category-home"
-                      class="category"
+                      class="category replay-hidden"
                       value="paneHome"
                       helpTopic="prefs-home"
                       data-l10n-id="category-home"
@@ -155,7 +155,7 @@
 
       <spacer flex="1"/>
 
-      <hbox class="sidebar-footer-button" pack="center">
+      <hbox class="sidebar-footer-button replay-hidden" pack="center">
         <label id="addonsButton" is="text-link">
           <hbox align="center">
             <image class="sidebar-footer-icon addons-icon"/>

--- a/browser/themes/shared/preferences/preferences.inc.css
+++ b/browser/themes/shared/preferences/preferences.inc.css
@@ -1156,3 +1156,7 @@ richlistitem .text-link:hover {
 .featureGateDescription {
   margin-inline-start: 28px;
 }
+
+.replay-hidden {
+  display: none;
+}


### PR DESCRIPTION
* Adds `replay.support.baseURL` preference pointing to replay docs
* Update "Replay Support" links to use the new pref
* Hides the Home menu which contains preferences that likely shouldn't be changed for replay
* Hides the addons menu - should we?

There are lots of links to mozilla for "Learn more ..." links. I'm not sure what to do with these. On one hand, scrubbing all the mozilla references seems best but in the near term I'm not sure it's worth recreating that content.

Fixes #363 


https://user-images.githubusercontent.com/788456/118370926-dd57bc80-b55e-11eb-9cf0-13cfc8f76f15.mp4

