### PR TITLE
Change default theme to alpenglow

### DIFF
--- a/browser/branding/recordreplay/pref/firefox-branding.js
+++ b/browser/branding/recordreplay/pref/firefox-branding.js
@@ -4,6 +4,8 @@
 
 // This file contains branding-specific prefs.
 
+pref("extensions.activeThemeID", "firefox-alpenglow@mozilla.org");
+
 pref("startup.homepage_override_url", "");
 pref("startup.homepage_welcome_url", "");
 pref("startup.homepage_welcome_url.additional", "");

--- a/browser/components/customizableui/CustomizableUI.jsm
+++ b/browser/components/customizableui/CustomizableUI.jsm
@@ -44,7 +44,7 @@ XPCOMUtils.defineLazyPreferenceGetter(
   false
 );
 
-const kDefaultThemeID = "default-theme@mozilla.org";
+const kDefaultThemeID = "firefox-alpenglow@mozilla.org";
 
 const kSpecialWidgetPfx = "customizableui-special-";
 
@@ -222,6 +222,12 @@ var CustomizableUIInternal = {
       let addons = await AddonManager.getAddonsByTypes(["theme"]);
       gDefaultTheme = addons.find(addon => addon.id == kDefaultThemeID);
       gSelectedTheme = addons.find(addon => addon.isActive) || gDefaultTheme;
+
+      // [REPLAY] Coerce theme to be the replay theme on startup
+      if(!gDefaultTheme.isActive) {
+        await gDefaultTheme.enable();
+        gSelectedTheme = gDefaultTheme;
+      }
     });
 
     this.addListener(this);

--- a/toolkit/mozapps/extensions/internal/AddonSettings.jsm
+++ b/toolkit/mozapps/extensions/internal/AddonSettings.jsm
@@ -125,7 +125,7 @@ if (
   makeConstant("EXPERIMENTS_ENABLED", false);
 }
 
-makeConstant("DEFAULT_THEME_ID", "default-theme@mozilla.org");
+makeConstant("DEFAULT_THEME_ID", "firefox-alpenglow@mozilla.org");
 
 // SCOPES_SIDELOAD is a bitflag for what scopes we will load new extensions from when we scan the directories.
 // If a build allows sideloading, or we're in automation, we'll also allow use of the preference.


### PR DESCRIPTION
Replay: Now in glorious Alpenglow!

This will only set the theme for new installs. I'm still tracking down how we might update existing settings.

Relates to #350