### PR TITLE
Add preference to record all content processes, fixes #377

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -820,6 +820,9 @@ pref("devtools.recordreplay.uploadSourceMaps", true);
 // Set this to submit recordings to the test server instead of replaying them.
 pref("devtools.recordreplay.submitTestRecordings", false);
 
+// Set this to record all tabs and add an explicit "save" button to the UI.
+pref("devtools.recordreplay.alwaysRecord", false);
+
 // Preferences for the new performance panel. Note that some preferences are duplicated
 // with a ".remote" postfix. This is because we have one set of preference for local
 // profiling, and a second set for remote profiling.


### PR DESCRIPTION
This patch adds a preference (off by default) to record all content processes, like we do with the RECORD_ALL_CONTENT env var. When this pref is set recordings still need to be explicitly stopped to be saved --- we don't automatically finish recordings when killing the content processes like we do with RECORD_ALL_CONTENT.