### PR TITLE
Set record/replay server and driver in ContentParent if not available

### DIFF
--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1575,7 +1575,7 @@ async function runTestScript() {
   eval(text);
 }
 
-// See also ContentParent::ContentParent
+// See also GetRecordReplayDispatchServer in ContentParent.cpp
 function getDispatchServer(url) {
   const address = env.get("RECORD_REPLAY_SERVER");
   if (address) {
@@ -1603,7 +1603,7 @@ function DriverJSON() {
   return `${getRecordReplayPlatform()}-recordreplay.json`;
 }
 
-// See also ContentParent::ContentParent
+// See also SetupRecordReplayDriver in ContentParent.cpp
 function driverFile() {
   const file = Services.dirsvc.get("UAppData", Ci.nsIFile);
   file.append(DriverName());

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1575,6 +1575,7 @@ async function runTestScript() {
   eval(text);
 }
 
+// See also ContentParent::ContentParent
 function getDispatchServer(url) {
   const address = env.get("RECORD_REPLAY_SERVER");
   if (address) {
@@ -1602,6 +1603,7 @@ function DriverJSON() {
   return `${getRecordReplayPlatform()}-recordreplay.json`;
 }
 
+// See also ContentParent::ContentParent
 function driverFile() {
   const file = Services.dirsvc.get("UAppData", Ci.nsIFile);
   file.append(DriverName());

--- a/dom/ipc/ContentParent.cpp
+++ b/dom/ipc/ContentParent.cpp
@@ -2764,6 +2764,16 @@ ContentParent::ContentParent(const nsACString& aRemoteType,
   : ContentParent(aRemoteType, nsFakePluginTag::NOT_JSPLUGIN,
                   aRecordingDispatchAddress) {}
 
+static nsString GetRecordReplayDriverName() {
+#ifdef XP_MACOSX
+  return u"macOS-recordreplay.so"_ns;
+#elif defined(XP_LINUX)
+  return u"linux-recordreplay.so"_ns;
+#else
+  MOZ_CRASH("GetRecordReplayDriverName unknown platform");
+#endif
+}
+
 ContentParent::ContentParent(const nsACString& aRemoteType, int32_t aJSPluginID,
                              const nsAString& aRecordingDispatchAddress)
     : mSelfRef(nullptr),
@@ -2795,11 +2805,44 @@ ContentParent::ContentParent(const nsACString& aRemoteType, int32_t aJSPluginID,
                         "XXX(nika): How are we creating a JSPlugin?");
 
   if (RecordAllContentProcesses()) {
+    // When recording all processes we won't be supplied with the dispatch
+    // address to use. Figure it out ourselves.
+    //
+    // See also getDispatchServer in DevToolsStartup.jsm
     char* server = getenv("RECORD_REPLAY_SERVER");
     if (server) {
       mRecordingDispatchAddress = NS_ConvertUTF8toUTF16(nsCString(server));
     } else {
-      fprintf(stderr, "Warning: RECORD_REPLAY_SERVER not set, can't record.\n");
+      nsresult rv = Preferences::GetString("devtools.recordreplay.cloudServer",
+                                           mRecordingDispatchAddress);
+      if (NS_FAILED(rv)) {
+        fprintf(stderr, "Warning: Can't determine record/replay server, can't record.\n");
+        mRecordingDispatchAddress.SetLength(0);
+      }
+    }
+
+    // When recording all content processes the devtools code might not have
+    // updated the driver and set the corresponding env var yet.
+    //
+    // See also driverFile in DevToolsStartup.jsm
+    char* driver = getenv("RECORD_REPLAY_DRIVER");
+    if (!driver) {
+      nsCOMPtr<nsIFile> driverFile;
+      nsAutoString driverPath;
+      bool driverExists = false;
+      if (NS_SUCCEEDED(NS_GetSpecialDirectory(XRE_USER_APP_DATA_DIR,
+                                              getter_AddRefs(driverFile))) &&
+          NS_SUCCEEDED(driverFile->Append(GetRecordReplayDriverName())) &&
+          NS_SUCCEEDED(driverFile->Exists(&driverExists)) &&
+          driverExists &&
+          NS_SUCCEEDED(driverFile->GetPath(driverPath))) {
+        setenv("RECORD_REPLAY_DRIVER",
+               NS_ConvertUTF16toUTF8(driverPath).get(),
+               /* overwrite */ false);
+      } else {
+        fprintf(stderr, "Warning: Can't find record/replay driver, can't record.\n");
+        mRecordingDispatchAddress.SetLength(0);
+      }
     }
   }
 


### PR DESCRIPTION
This fixes a couple problems with the patch in #377 that showed up in the released browser.  When recording all tabs the ContentParent needs to know the server/driver to use.  When running using playwright or in local testing (like I was doing earlier) this is specified via the environment, but in the normal user context these are set by DevToolsStartup.jsm, which won't run until after we've already started creating content processes.

This duplicates some of the DevToolsStartup.jsm logic in ContentParent to get the default values for the server and driver, which we'll want to consolidate at some point.