### PR TITLE
Hide search engine suggestions from url bar

### DIFF
--- a/browser/branding/recordreplay/pref/firefox-branding.js
+++ b/browser/branding/recordreplay/pref/firefox-branding.js
@@ -37,3 +37,9 @@ pref("app.update.badgeWaitTime", 0);
 // Number of usages of the web console.
 // If this is less than 5, then pasting code into the web console is disabled
 pref("devtools.selfxss.count", 5);
+
+// Disable search suggestions
+pref("browser.urlbar.suggest.searches",             false);
+pref("browser.urlbar.suggest.topsites",             false);
+pref("browser.urlbar.suggest.engines",              false);
+pref("browser.urlbar.suggest.quicksuggest",         false);

--- a/browser/components/urlbar/UrlbarSearchOneOffs.jsm
+++ b/browser/components/urlbar/UrlbarSearchOneOffs.jsm
@@ -52,6 +52,9 @@ class UrlbarSearchOneOffs extends SearchOneOffs {
    *   True to enable, false to disable.
    */
   enable(enable) {
+    // [Replay] Suppress one-off search suggestions in the UrlBar
+    enable = false;
+
     if (enable) {
       this.telemetryOrigin = "urlbar";
       this.style.display = "";


### PR DESCRIPTION
Removing search engine suggestions per user feedback.

![urlbar-search](https://user-images.githubusercontent.com/788456/119079126-5bc3bc80-b9ac-11eb-9f9f-033110f4e5d5.gif)
