### PR TITLE
Show the upload tab as soon as possible

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -26,7 +26,11 @@ const { Debugger, RecordReplayControl, Services, InspectorUtils } = sandbox;
 const isRecordingOrReplaying = !!RecordReplayControl.onNewSource;
 
 if (isRecordingOrReplaying) {
-  Services.cpmm.sendAsyncMessage("RecordingStarting");
+  const recordingId = RecordReplayControl.recordingId();
+
+  Services.cpmm.sendAsyncMessage("RecordingStarting", {
+    recordingId
+  });
 }
 
 const log = RecordReplayControl.log;


### PR DESCRIPTION
Waiting for `RecordingFinished` can take 5+ seconds which is reasonable for what it is doing, but way too slow for a responsive ui.

This PR takes a different approach. When the recording starts, we get the recording id. And when the recording finishes we immediately show the new replay tab.

I'm sure this PR is rough in many ways and will need some adjusting.