### PR TITLE
Update new tab url to use custom replay page

### DIFF
--- a/browser/modules/AboutNewTab.jsm
+++ b/browser/modules/AboutNewTab.jsm
@@ -19,7 +19,9 @@ XPCOMUtils.defineLazyModuleGetters(this, {
     "resource://gre/modules/remotepagemanager/RemotePageManagerParent.jsm",
 });
 
-const ABOUT_URL = "about:newtab";
+// [Replay] - Set custom about:newtab url. Also set _newTabURLOverridden to
+// ensure it is preloaded by NewTabPagePreloading.jsm
+const ABOUT_URL = "https://replay.io/new-tab";
 const PREF_ACTIVITY_STREAM_DEBUG = "browser.newtabpage.activity-stream.debug";
 const TOPIC_APP_QUIT = "quit-application-granted";
 const BROWSER_READY_NOTIFICATION = "sessionstore-windows-restored";
@@ -42,7 +44,7 @@ const AboutNewTab = {
   activityStreamDebug: false,
 
   _newTabURL: ABOUT_URL,
-  _newTabURLOverridden: false,
+  _newTabURLOverridden: true,
 
   /**
    * init - Initializes an instance of Activity Stream if one doesn't exist already


### PR DESCRIPTION
Sets a custom endpoint for `about:newtab` and flags it overridden so it is preloaded.