### PR TITLE
Emit finished after we have registered the replay

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -187,14 +187,14 @@ class Recording extends EventEmitter {
     try {
       const authId = getLoggedInUserAuthId();
 
-      this.emit("finished", data);
-
       // Upload the metadata without the screenshot earlier to unblock the
       // upload screen
       await sendCommand("Internal.setRecordingMetadata", {
         authId,
         recordingData: {...data, lastScreenData: "", lastScreenMimeType: ""},
       });
+
+      this.emit("finished", data);
 
       // If we locked the recording because of sourcemaps, we should wait
       // that the lock to be initialized before emitting the event so that


### PR DESCRIPTION
So, i don't love this because it does add a delay for opening the new tab, but it will help the issue we're seeing where we're skipping the upload screen.

When we revisit creating replays via API Keys the backend will know who is creating the replay and we won't have this problem