### PR TITLE
Add support for replay: URL scheme

### DIFF
--- a/browser/app/macbuild/Contents/Info.plist.in
+++ b/browser/app/macbuild/Contents/Info.plist.in
@@ -218,6 +218,16 @@
 				<string>file</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>io.replay.GeckoUrlScheme</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>replay</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>@MAC_BUNDLE_VERSION@</string>


### PR DESCRIPTION
Adds support for launching `replay:`-prefixed URLs in gecko on Mac. Initially, it only supports `replay:library` but more mappings can be added to `replaySchemeMap` in the future.

Relates to RecordReplay/devtools#2688