### PR TITLE
Log a console error when a recording is unusable.

### DIFF
--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1887,6 +1887,8 @@ function onRecordingStarted(recording) {
   }
 
   recording.on("unusable", function(name, data) {
+    // Log the reason so we can see in our CI logs when something went wrong.
+    console.error("Unstable recording: " + data.why);
     const browser = getBrowser();
 
     reloadAndClearRecordingState(browser, `about:replay?error=${data.why}`);


### PR DESCRIPTION
The test failures in https://github.com/RecordReplay/backend/pull/2353/checks?check_run_id=2834113471 have some
```
2021-06-15T22:36:52.6582086Z console.error:
2021-06-15T22:36:52.6582892Z   Error: Unable to find browser for recording: getBrowserForPid@resource:///modules/DevToolsStartup.jsm:1802:9
2021-06-15T22:36:52.6583841Z getBrowser@resource:///modules/DevToolsStartup.jsm:1814:17
2021-06-15T22:36:52.6584866Z onRecordingStarted/<@resource:///modules/DevToolsStartup.jsm:1836:5
2021-06-15T22:36:52.6585675Z emit@resource://gre/modules/EventEmitter.jsm:160:20
2021-06-15T22:36:52.6586503Z _onUnusable@resource://devtools/server/actors/replay/connection.js:231:10
2021-06-15T22:36:52.6587457Z receiveMessage@resource://devtools/server/actors/replay/connection.js:133:35
```
logs which means it tried to navigate to the unusable-recording tab and failed to do so. I'm adding this logging so that we can at least see the unusable message in the logs.

