### PR TITLE
Save recording when recording all content processes, for backend issu…

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -382,11 +382,18 @@ function Target_getHTMLSource({ url }) {
   return { contents };
 }
 
+// We add the URI of the first loaded page as recording metadata.
+let gHasHTMLContent = false;
+
 function OnHTMLContent(data) {
   const { uri, contents } = JSON.parse(data);
   if (gHtmlContent.has(uri)) {
     gHtmlContent.get(uri).content += contents;
   } else {
+    if (!gHasHTMLContent) {
+      gHasHTMLContent = true;
+      RecordReplayControl.addMetadata({ uri });
+    }
     gHtmlContent.set(uri, { content: contents, contentType: "text/html" });
   }
 }


### PR DESCRIPTION
…e 2313

This uses the new RecordReplaySaveRecording API in gecko-dev to write information about saved recordings to a file shared with other targets, and write the recording to disk when no dispatch server was specified.  This only happens when we are recording all content processes, i.e. during playwright test runs but not when users are running the browser explicitly.