### PR TITLE
Don't generate previews for scripted proxies, fix class name, fixes b…

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -1201,7 +1201,7 @@ function createProtocolObject(objectId, level) {
     return { objectId, className: "BadObjectId" };
   }
 
-  const className = obj.class;
+  const className = obj.isProxy ? "Proxy" : obj.class;
   let preview;
   if (level != "none") {
     preview = new ProtocolObjectPreview(obj, level).fill();
@@ -1214,7 +1214,16 @@ function createProtocolObject(objectId, level) {
 function isObjectBlacklisted(obj) {
   // Accessing Storage object properties can cause hangs when trying to
   // communicate with the non-existent parent process.
-  return obj.class == "Storage";
+  if (obj.class == "Storage") {
+    return true;
+  }
+
+  // Don't inspect scripted proxies, as we could end up calling into script.
+  if (obj.isProxy) {
+    return true;
+  }
+
+  return false;
 }
 
 // Return whether an object's property should be ignored when generating previews.


### PR DESCRIPTION
…ackend issue 474

Currently scripted proxies are previewed like the target object instead of the proxy itself.  From the crashes in https://github.com/RecordReplay/backend/issues/474 it looks like we can end up calling into scripted proxy code while trying to generate previews, presumably because we're generating a preview for a scripted proxy.  It seems best to avoid inspecting the contents of scripted proxies to reduce the risk of calling into script (which we don't want to do while generating previews), and to change the class name reported to the protocol to make it clear this is a proxy.