### PR TITLE
Default to saving recordings to disk when recording all content, for …

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -382,6 +382,14 @@ function Target_getHTMLSource({ url }) {
   return { contents };
 }
 
+function isInterestingHTML(uri) {
+  // Ignore URIs loaded into extension content processes.
+  if (uri.startsWith("data:text/html") && uri.includes("moz-extension://")) {
+    return false;
+  }
+  return true;
+}
+
 // We add the URI of the first loaded page as recording metadata.
 let gHasHTMLContent = false;
 
@@ -390,7 +398,7 @@ function OnHTMLContent(data) {
   if (gHtmlContent.has(uri)) {
     gHtmlContent.get(uri).content += contents;
   } else {
-    if (!gHasHTMLContent) {
+    if (!gHasHTMLContent && isInterestingHTML(uri)) {
       gHasHTMLContent = true;
       RecordReplayControl.addMetadata({ uri });
     }

--- a/dom/ipc/ContentParent.cpp
+++ b/dom/ipc/ContentParent.cpp
@@ -2764,16 +2764,6 @@ ContentParent::ContentParent(const nsACString& aRemoteType,
   : ContentParent(aRemoteType, nsFakePluginTag::NOT_JSPLUGIN,
                   aRecordingDispatchAddress) {}
 
-static nsString GetRecordReplayDriverName() {
-#ifdef XP_MACOSX
-  return u"macOS-recordreplay.so"_ns;
-#elif defined(XP_LINUX)
-  return u"linux-recordreplay.so"_ns;
-#else
-  MOZ_CRASH("GetRecordReplayDriverName unknown platform");
-#endif
-}
-
 // Get the dispatch address to use when recording/replaying.
 // See also getDispatchServer in DevToolsStartup.jsm
 static nsString GetRecordReplayDispatchServer() {
@@ -2782,12 +2772,9 @@ static nsString GetRecordReplayDispatchServer() {
     return NS_ConvertUTF8toUTF16(nsCString(server));
   }
 
-  nsString pref;
-  nsresult rv = Preferences::GetString("devtools.recordreplay.cloudServer", pref);
-  if (NS_FAILED(rv)) {
-    fprintf(stderr, "Warning: Can't determine record/replay server, can't record.\n");
-  }
-  return pref;
+  // When recording all content processes, if RECORD_REPLAY_SERVER isn't specified
+  // then we save recordings to disk.
+  return NS_ConvertUTF8toUTF16(nsCString("*"));
 }
 
 ContentParent::ContentParent(const nsACString& aRemoteType, int32_t aJSPluginID,

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -204,13 +204,17 @@ extern "C" {
 
 MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
   // Parse command line options for the process kind and recording file.
-  Maybe<char*> dispatchAddress;
+  Maybe<const char*> dispatchAddress;
   int argc = *aArgc;
   char** argv = *aArgv;
   for (int i = 0; i < argc; i++) {
     if (!strcmp(argv[i], "-recordReplayDispatch")) {
       MOZ_RELEASE_ASSERT(dispatchAddress.isNothing() && i + 1 < argc);
-      dispatchAddress.emplace(argv[i + 1]);
+      const char* arg = argv[i + 1];
+
+      // The special dispatch address "*" is used to indicate that we should
+      // save the recording itself to disk.
+      dispatchAddress.emplace(strcmp(arg, "*") ? arg : nullptr);
     }
   }
   MOZ_RELEASE_ASSERT(dispatchAddress.isSome());


### PR DESCRIPTION
…backend issue 2313

This fixes a few problems with recording using playwright:

* We were setting a default dispatch server when recording all content so that recordings were always being uploaded instead of written out to disk.
* Fix some places where we weren't dealing with not having a recording ID even if the recording is usable.
* Avoid adding metadata for moz-extension URLs which frequently get loaded into content processes and clutter up the replay-recordings CLI output.