### PR TITLE
Keep track of potentially sensitive recording operations when running…

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -527,15 +527,11 @@ function buildRecordingOperations() {
     }
   }
 
-  const rv = {
+  return {
     scriptDomains,
     cookies: cookies ? [...cookies] : undefined,
     storage: storage ? [...storage] : undefined,
   };
-
-  log(`SendRecordingFinished ${JSON.stringify(rv)}`);
-
-  return rv;
 
   function localStorageDomain(value) {
     // Local storage values include the domain with its characters reversed,

--- a/dom/indexedDB/IDBFactory.cpp
+++ b/dom/indexedDB/IDBFactory.cpp
@@ -47,6 +47,10 @@
 #  include "nsContentUtils.h"  // For assertions.
 #endif
 
+namespace mozilla::recordreplay {
+  extern void AddRecordingOperation(const char* aKind, const char* aValue);
+}
+
 namespace mozilla::dom {
 
 using namespace mozilla::dom::indexedDB;
@@ -587,6 +591,10 @@ RefPtr<IDBOpenDBRequest> IDBFactory::OpenInternal(
     nsCString origin =
         principalInfo.get_ContentPrincipalInfo().originNoSuffix();
     isInternal = QuotaManager::IsOriginInternal(origin);
+
+    if (!isInternal) {
+      recordreplay::AddRecordingOperation("indexedDB", origin.get());
+    }
   }
 
   // Allow storage attributes for add-ons independent of the pref.

--- a/dom/storage/LocalStorageCache.cpp
+++ b/dom/storage/LocalStorageCache.cpp
@@ -19,6 +19,11 @@
 #include "nsThreadUtils.h"
 
 namespace mozilla {
+
+namespace recordreplay {
+  extern void AddRecordingOperation(const char* aKind, const char* aValue);
+}
+
 namespace dom {
 
 #define DOM_STORAGE_CACHE_KEEP_ALIVE_TIME_MS 20000
@@ -75,6 +80,8 @@ LocalStorageCache::LocalStorageCache(const nsACString* aOriginNoSuffix)
       mPersistent(false),
       mPreloadTelemetryRecorded(false) {
   MOZ_COUNT_CTOR(LocalStorageCache);
+
+  recordreplay::AddRecordingOperation("localStorage", mOriginNoSuffix.get());
 }
 
 LocalStorageCache::~LocalStorageCache() {

--- a/netwerk/cookie/CookieServiceChild.cpp
+++ b/netwerk/cookie/CookieServiceChild.cpp
@@ -34,6 +34,11 @@
 using namespace mozilla::ipc;
 
 namespace mozilla {
+
+namespace recordreplay {
+  extern void AddRecordingOperation(const char* aKind, const char* aValue);
+}
+
 namespace net {
 
 // Pref string constants
@@ -263,6 +268,8 @@ void CookieServiceChild::RecordDocumentCookie(Cookie* aCookie,
   nsAutoCString baseDomain;
   CookieCommons::GetBaseDomainFromHost(mTLDService, aCookie->Host(),
                                        baseDomain);
+
+  recordreplay::AddRecordingOperation("cookie", baseDomain.get());
 
   CookieKey key(baseDomain, aAttrs);
   CookiesList* cookiesList = nullptr;
@@ -497,6 +504,8 @@ CookieServiceChild::SetCookieStringFromDocument(
     nsTArray<CookieStruct> cookiesToSend;
     cookiesToSend.AppendElement(cookie->ToIPC());
 
+    recordreplay::AddRecordingOperation("cookie", baseDomain.get());
+
     // Asynchronously call the parent.
     SendSetCookies(baseDomain, attrs, documentURI, false, cookiesToSend);
   }
@@ -618,6 +627,8 @@ CookieServiceChild::SetCookieStringFromHttp(nsIURI* aHostURI,
 
   // Asynchronously call the parent.
   if (CanSend() && !cookiesToSend.IsEmpty()) {
+    recordreplay::AddRecordingOperation("cookie", baseDomain.get());
+
     SendSetCookies(baseDomain, attrs, aHostURI, true, cookiesToSend);
   }
 


### PR DESCRIPTION
… scripts or accessing cookies / local storage, for backend issue 2164

This adds some information about potentially sensitive operations which the recording performed to the packet of data sent up to the UI process in SendRecordingFinished.  These operations describe the domains which ran scripts in the recording, had cookies accessed, or used local storage.

For example, recording npr.org generates the data below.

```
{
  "scriptDomains": [
    "www.npr.org",
    "static-assets.npr.org",
    "bundles.npr.org",
    "js.stripe.com",
    "www.googletagmanager.com",
    "pym.nprapps.org",
    "carebot.nprapps.org",
    "apps.npr.org",
    "m.stripe.network",
    "www.google-analytics.com",
    "connect.facebook.net"
  ],
  "cookies": [
    "npr.org",
    "stripe.com"
  ],
  "storage": [
    "www.npr.org",
    "m.stripe.network"
  ]
}
```