### PR TITLE
Add config sample for building on apple silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,9 +164,8 @@ lextab.py
 !.vscode/extensions.json
 !.vscode/tasks.json
 
-MacOSX10.11.sdk
-MacOSX10.12.sdk
-MacOSX10.12.sdk.tar.xz
+MacOSX*.sdk
+MacOSX*.sdk.tar.xz
 wr-opt/
 
 # Ignore various raptor performance framework files

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ the Record Replay gecko based browser.
 
 1. Make sure that you are using Python v2.7
 2. `cp mozconfig.macsample mozconfig`
-3. Download `MacOSX10.12.sdk.tar.xz` from https://github.com/phracker/MacOSX-SDKs/releases
-4. untar `MacOSX10.12.sdk.tar.xz` in the repo root to create a `MacOSX10.12.sdk` directory
+3. Download `MacOSX11.1.sdk.tar.xz` from https://github.com/phracker/MacOSX-SDKs/releases
+4. untar `MacOSX11.1.sdk.tar.xz` in the repo root to create a `MacOSX11.1.sdk` directory
 5. run `./mach bootstrap` and select (2) Firefox Desktop
 6. run `node build`
+   * On Apple Silicon, you many need to run `RUSTC_BOOTSTRAP=qcms node build` to build successfully.
 7. run `./mach run`
 
 **Linux**

--- a/mozconfig.macsample
+++ b/mozconfig.macsample
@@ -4,7 +4,8 @@ mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/rr-opt
 mk_add_options MOZ_MAKE_FLAGS="-j12"
 mk_add_options AUTOCLOBBER=1
 
-ac_add_options --with-macos-sdk=$topsrcdir/MacOSX10.12.sdk
+ac_add_options --target=x86_64-apple-darwin
+ac_add_options --with-macos-sdk=$topsrcdir/MacOSX11.1.sdk
 ac_add_options --with-branding=browser/branding/recordreplay
 ac_add_options --with-app-name=replay
 ac_add_options --with-app-basename=Replay

--- a/python/mozboot/mozboot/osx.py
+++ b/python/mozboot/mozboot/osx.py
@@ -194,7 +194,8 @@ class OSXBootstrapper(BaseBootstrapper):
                 "Bootstrap is not supported on Apple Silicon yet.\n"
                 "Please see instructions at https://bit.ly/36bUmEx in the meanwhile"
             )
-            sys.exit(1)
+            # [Replay] - Seems to build okay with 11.1 SDK Headers as of 7/9/2021
+            # sys.exit(1)
 
         self.minor_version = version.split(".")[1]
 


### PR DESCRIPTION
* Adds mozconfig sample file with the following changes:
  * Updates SDK to use 11.1 headers
  * Sets the target to be `x86_64-apple-darwin` so it is compatible with the backend
  * Disables a check in `./mach bootstrap` that aborts for apple silicon but doesn't appear required (at least for our purposes)

TODO:
* Setting RUSTC_BOOTSTRAP in the mozconfig doesn't seem to work like I thought it would. There must be a way to do this beyond requiring it on the command line before `./mach build` but I haven't found it yet.