### PR TITLE
Centralize socket connection messaging.

### DIFF
--- a/devtools/server/actors/replay/connection-worker.js
+++ b/devtools/server/actors/replay/connection-worker.js
@@ -6,24 +6,55 @@
 "use strict";
 
 // Sockets for communicating with the Record Replay cloud service.
-const gUploadSockets = new Map();
+const gSockets = new Map();
 
 self.addEventListener("message", makeInfallible(onMainThreadMessage));
 
 function onMainThreadMessage({ data }) {
   switch (data.kind) {
-    case "openChannel":
-      openUploadSocket(data.id, data.address);
+    case "openChannel": {
+      const socket = new ProtocolSocket(data.address);
+      gSockets.set(data.channelId, socket);
+      socket.onStateChange = state => {
+        postMessage({
+          kind: "stateChange",
+          channelId: data.channelId,
+          state,
+        });
+      };
       break;
-    case "sendCommand":
-      gUploadSockets.get(data.id).send(JSON.stringify(data.command));
+    }
+    case "sendCommand": {
+      gSockets.get(data.channelId).sendCommand(data.method, data.params)
+        .catch(err => {
+          postError(`UnexpectedCommandException: ${err}`);
+          return {
+            result: null,
+            error: {
+              code: -2,
+              message: "Unexpected internal error"
+            }
+          };
+        })
+        .then(({ result, error }) => {
+          postMessage({
+            kind: "commandResponse",
+            channelId: data.channelId,
+            commandId: data.commandId,
+            result,
+            error
+          });
+        });
       break;
-    case "sendBinaryData":
-      gUploadSockets.get(data.id).send(data.buf);
+    }
+    case "closeChannel": {
+      const socket = gSockets.get(data.channelId);
+      if (socket) {
+        gSockets.delete(data.channelId);
+        socket.close();
+      }
       break;
-    case "closeChannel":
-      destroyUploadSocket(data.id);
-      break;
+    }
     default:
       postError(`Unknown event kind ${data.kind}`);
   }
@@ -31,110 +62,149 @@ function onMainThreadMessage({ data }) {
 
 // Every upload uses its own socket. This allows other communication with the
 // cloud service even if the upload socket has a lot of pending data to send.
-function UploadSocket(address) {
-  this.address = address;
-  this.open = false;
-  this.pending = [];
-  this.closed = false;
-  this.inProgress = new Set();
+class ProtocolSocket {
+  constructor(address) {
+    this._address = address;
+    this._state = "connecting";
+    this._msgId = 1;
+    this._pendingMessages = new Map();
+    this._socket = null;
+    this._onStateChangeCallback = null;
 
-  this.initialize();
-}
+    this._initialize();
+  }
 
-UploadSocket.prototype = {
-  initialize() {
-    this.socket = new WebSocket(this.address);
-    this.socket.onopen = makeInfallible(() => this.onOpen());
-    this.socket.onclose = makeInfallible(() => this.onClose());
-    this.socket.onmessage = makeInfallible(onServerMessage, this);
-    this.socket.onerror = makeInfallible(() => this.onError());
-  },
+  get onStateChange() {
+    return this._onStateChangeCallback;
+  }
 
-  onOpen() {
-    this.open = true;
-    this.pending.forEach(cb => cb());
-    this.pending.length = 0;
+  set onStateChange(callback) {
+    this._onStateChangeCallback = callback;
+    this._notifyStateChange();
+  }
 
-    updateStatus("");
-  },
+  _initialize() {
+    this._socket = new WebSocket(this._address);
+    this._socket.onopen = makeInfallible(() => this._onOpen());
+    this._socket.onclose = makeInfallible(() => this._onClose());
+    this._socket.onmessage = makeInfallible(evt => this._onServerMessage(evt));
+    this._socket.onerror = makeInfallible(() => this._onError());
+  }
 
-  onClose() {
-    if (!this.closed) {
-      const ids = Array.from(this.inProgress);
-      this.inProgress.clear();
-      for (const id of ids) {
-        postMessage({
-          kind: "commandResponse",
-          msg: {
-            id,
-            error: {
-              code: -1,
-              message: "Connection Lost",
-            },
-          },
-        });
+  _onOpen() {
+    this._msgId = 1;
+    this._state = "open";
+
+    for (const entry of this._pendingMessages.values()) {
+      if (typeof entry.msg !== "string") {
+        postError("Unexpected non-pending message");
+        return;
       }
-
-      this.open = false;
-      updateStatus("cloudReconnecting.label");
-      setTimeout(() => this.initialize(), 3000);
+      doSend(this._socket, entry.msg);
+      entry.msg = null;
     }
-  },
 
-  onError() {
-    if (!this.closed) {
-      updateStatus("cloudError.label");
-    }
-  },
+    this._notifyStateChange();
+  }
 
-  send(msg) {
-    if (this.open) {
-      this.inProgress.add(msg.id);
-      doSend(this.socket, msg);
-    } else {
-      this.pending.push(() => {
-        this.inProgress.add(msg.id);
-        doSend(this.socket, msg);
-      });
+  _onClose() {
+    if (this._state === "closed") {
+      return;
     }
-  },
+
+    for (const entry of this._pendingMessages.values()) {
+      entry.resolve(makeUnavailableResponse());
+    }
+    this._pendingMessages.clear();
+
+    this._state = "connecting";
+    this._notifyStateChange();
+    setTimeout(() => this._initialize(), 3000);
+  }
+
+  _onError() {
+    this._state = "error";
+    this._notifyStateChange();
+  }
+
+  _notifyStateChange() {
+    this._onStateChangeCallback?.(this._state);
+  }
+
+  _onServerMessage(evt) {
+    const data = JSON.parse(evt.data);
+    if (data.id == null) {
+      // Ignore events.
+      return;
+    }
+
+    const entry = this._pendingMessages.get(data.id);
+    this._pendingMessages.delete(data.id);
+    if (!entry) {
+      postError(`Unexpected response id ${data.id}`);
+      return;
+    }
+    entry.resolve(data);
+  }
+
+  async sendCommand(method, params = {}) {
+    if (this._state !== "open" && this._state !== "connecting") {
+      return makeUnavailableResponse();
+    }
+
+    const result = await new Promise(resolve => {
+      const msgId = this._msgId++;
+      const entry = {
+        msgId,
+        resolve,
+        msg: JSON.stringify({
+          id: msgId,
+          method,
+          params,
+        }),
+      };
+      this._pendingMessages.set(msgId, entry);
+
+      if (this._state === "open") {
+        doSend(this._socket, entry.msg);
+        entry.msg = null;
+      }
+    });
+
+    return {
+      error: result.error,
+      result: result.result,
+    };
+  }
 
   close() {
-    this.closed = true;
-    this.socket.close();
-  },
-};
+    for (const entry of this._pendingMessages.values()) {
+      entry.resolve(makeUnavailableResponse());
+    }
+    this._pendingMessages.clear();
 
-function openUploadSocket(id, address) {
-  gUploadSockets.set(id, new UploadSocket(address));
-}
-
-function destroyUploadSocket(id) {
-  if (gUploadSockets.has(id)) {
-    gUploadSockets.get(id).close();
-    gUploadSockets.delete(id);
+    this._state = "closed";
+    this._socket.close();
+    this._notifyStateChange();
   }
 }
 
-function updateStatus(status) {
-  postMessage({ kind: "updateStatus", status });
-}
-
-function onServerMessage(evt) {
-  const data = JSON.parse(evt.data);
-
-  if (data.id) {
-    this.inProgress.delete(data.id);
-  }
-  postMessage({ kind: "commandResponse", msg: data });
+function makeUnavailableResponse() {
+  return {
+    result: null,
+    error: {
+      code: -1,
+      message: "Connection Unavailable",
+    },
+  };
 }
 
 const doSend = makeInfallible((socket, msg) => socket.send(msg));
 
-function makeInfallible(fn, thisv) {
+function makeInfallible(fn) {
   return (...args) => {
     try {
-      fn.apply(thisv, args);
+      fn(...args);
     } catch (e) {
       postError(e);
     }


### PR DESCRIPTION
Trying to separate the API from the implementation details for postMessage a bit more to help make things easier to follow. I want to add access token logic in here and I was having trouble with that  because this logic was so spread out.

