### PR TITLE
Fixed type/non-type hiding problem with LoaderPrivateAPI

### DIFF
--- a/browser/app/winlauncher/NtLoaderAPI.cpp
+++ b/browser/app/winlauncher/NtLoaderAPI.cpp
@@ -21,7 +21,7 @@ extern "C" MOZ_EXPORT nt::LoaderAPI* GetNtLoaderAPI(
   }
 
   freestanding::EnsureInitialized();
-  freestanding::LoaderPrivateAPI& api = freestanding::gLoaderPrivateAPI;
+  freestanding::LoaderPrivateAPI& api = freestanding::gLoaderPrivateAPI();
   api.SetObserver(aNewObserver);
 
   return &api;

--- a/browser/app/winlauncher/freestanding/DllBlocklist.cpp
+++ b/browser/app/winlauncher/freestanding/DllBlocklist.cpp
@@ -396,7 +396,7 @@ NTSTATUS NTAPI patched_NtMapViewOfSection(
 
   // Get the section name
   nt::MemorySectionNameBuf sectionFileName(
-      gLoaderPrivateAPI.GetSectionNameBuffer(*aBaseAddress));
+      gLoaderPrivateAPI().GetSectionNameBuffer(*aBaseAddress));
   if (sectionFileName.IsEmpty()) {
     ::NtUnmapViewOfSection(aProcess, *aBaseAddress);
     return STATUS_ACCESS_DENIED;

--- a/browser/app/winlauncher/freestanding/LoaderPrivateAPI.cpp
+++ b/browser/app/winlauncher/freestanding/LoaderPrivateAPI.cpp
@@ -120,7 +120,7 @@ namespace freestanding {
 // Note: For now we avoid the non-trivial initializer for gLoaderPrivateAPI
 // with this helper, to workaround issues calling the main initialization
 // routine in windows executables when replaying.
-LoaderPrivateAPI& LoaderPrivateAPI() {
+LoaderPrivateAPI& gLoaderPrivateAPI() {
   return gPrivateAPI;
 }
 

--- a/browser/app/winlauncher/freestanding/LoaderPrivateAPI.h
+++ b/browser/app/winlauncher/freestanding/LoaderPrivateAPI.h
@@ -54,8 +54,8 @@ class NS_NO_VTABLE LoaderPrivateAPI : public nt::LoaderAPI {
  */
 void EnsureInitialized();
 
-extern LoaderPrivateAPI& LoaderPrivateAPI();
-#define gLoaderPrivateAPI LoaderPrivateAPI()
+extern LoaderPrivateAPI& gLoaderPrivateAPI();
+// #define gLoaderPrivateAPI LoaderPrivateAPI()
 
 }  // namespace freestanding
 }  // namespace mozilla

--- a/browser/app/winlauncher/freestanding/ModuleLoadFrame.cpp
+++ b/browser/app/winlauncher/freestanding/ModuleLoadFrame.cpp
@@ -20,7 +20,7 @@ ModuleLoadFrame::ModuleLoadFrame(PCUNICODE_STRING aRequestedDllName)
   EnsureInitialized();
   sTopFrame.set(this);
 
-  gLoaderPrivateAPI.NotifyBeginDllLoad(mLoadInfo, &mContext, aRequestedDllName);
+  gLoaderPrivateAPI().NotifyBeginDllLoad(mLoadInfo, &mContext, aRequestedDllName);
 }
 
 ModuleLoadFrame::ModuleLoadFrame(nt::AllocatedUnicodeString&& aSectionName,
@@ -33,11 +33,11 @@ ModuleLoadFrame::ModuleLoadFrame(nt::AllocatedUnicodeString&& aSectionName,
       mLoadInfo(std::move(aSectionName), aMapBaseAddr, aLoadStatus) {
   sTopFrame.set(this);
 
-  gLoaderPrivateAPI.NotifyBeginDllLoad(&mContext, mLoadInfo.mSectionName);
+  gLoaderPrivateAPI().NotifyBeginDllLoad(&mContext, mLoadInfo.mSectionName);
 }
 
 ModuleLoadFrame::~ModuleLoadFrame() {
-  gLoaderPrivateAPI.NotifyEndDllLoad(mContext, mLoadNtStatus,
+  gLoaderPrivateAPI().NotifyEndDllLoad(mContext, mLoadNtStatus,
                                      std::move(mLoadInfo));
   sTopFrame.set(mPrev);
 }
@@ -77,7 +77,7 @@ void ModuleLoadFrame::NotifySectionMap(
     // the executable's dependent DLLs. If mozglue is present then
     // IsDefaultObserver will return false, indicating that we are beyond
     // initial process startup.
-    if (gLoaderPrivateAPI.IsDefaultObserver()) {
+    if (gLoaderPrivateAPI().IsDefaultObserver()) {
       OnBareSectionMap(std::move(aSectionName), aMapBaseAddr, aMapNtStatus,
                        aLoadStatus);
     }
@@ -125,7 +125,7 @@ NTSTATUS ModuleLoadFrame::SetLoadStatus(NTSTATUS aNtStatus,
     return aNtStatus;
   }
 
-  if (!gLoaderPrivateAPI.SubstituteForLSP(mLoadInfo.mRequestedDllName,
+  if (!gLoaderPrivateAPI().SubstituteForLSP(mLoadInfo.mRequestedDllName,
                                           aOutHandle)) {
     return aNtStatus;
   }

--- a/toolkit/recordreplay/moz.build
+++ b/toolkit/recordreplay/moz.build
@@ -10,7 +10,7 @@ SOURCES += [
     'HashTable.cpp',
     'JSControl.cpp',
     'ProcessRecordReplay.cpp',
-    'RecordReplayDriver.cpp',
+    # 'RecordReplayDriver.cpp',
 ]
 
 LOCAL_INCLUDES += [

--- a/toolkit/recordreplay/moz.build
+++ b/toolkit/recordreplay/moz.build
@@ -10,7 +10,7 @@ SOURCES += [
     'HashTable.cpp',
     'JSControl.cpp',
     'ProcessRecordReplay.cpp',
-    # 'RecordReplayDriver.cpp',
+    'RecordReplayDriver.cpp',
 ]
 
 LOCAL_INCLUDES += [


### PR DESCRIPTION
Commented out macro `gLoaderPrivateAPI`, renamed `LoaderPrivateAPI()` to `gLoaderPrivateAPI()` [as seen in current Firefox source](https://github.com/mozilla/gecko-dev/blob/48a854d36b6f2cb8466e10a23d6f33d2111669d5/browser/app/winlauncher/freestanding/LoaderPrivateAPI.h#L57), and converted all references of `gLoaderPrivateAPI` to `gLoaderPrivateAPI()`. This PR builds and runs natively on Windows 11.

Also commented out the `moz.build` line requiring `RecordReplayDriver.cpp`. I assume the file is necessary, as otherwise, that line wouldn't be there. But it was not present when I checked out the latest commit on `windows-port`.