### PR TITLE
Show an error when trying to record on macOS earlier than 10.14, fixe…

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -577,6 +577,11 @@ function SendRecordingUnusable(why) {
   Services.cpmm.sendAsyncMessage("RecordingUnusable", { why });
 }
 
+function SendRecordingUnsupported(why) {
+  Services.cpmm.sendAsyncMessage("RecordingStarting");
+  Services.cpmm.sendAsyncMessage("RecordingUnusable", { why });
+}
+
 function OnTestCommand(str) {
   const [_, cmd, arg] = /(.*?) (.*)/.exec(str);
   switch (cmd) {
@@ -639,6 +644,7 @@ function OnProtocolCommand(method, params) {
 const exports = {
   SendRecordingFinished,
   SendRecordingUnusable,
+  SendRecordingUnsupported,
   OnTestCommand,
   OnProtocolCommand,
   ClearPauseData,

--- a/dom/ipc/BrowserChild.cpp
+++ b/dom/ipc/BrowserChild.cpp
@@ -1130,9 +1130,7 @@ mozilla::ipc::IPCResult BrowserChild::RecvShow(
   // We have now done enough initialization for the record/replay system to
   // create checkpoints. Create a checkpoint now, in case this process never
   // paints later on (the usual place where checkpoints occur).
-  if (recordreplay::IsRecordingOrReplaying()) {
-    recordreplay::CreateCheckpoint();
-  }
+  recordreplay::CreateCheckpoint();
 
   UpdateVisibility();
 

--- a/layout/base/PresShell.cpp
+++ b/layout/base/PresShell.cpp
@@ -6245,9 +6245,7 @@ void PresShell::Paint(nsView* aViewToPaint, const nsRegion& aDirtyRegion,
   // When recording/replaying, create a checkpoint after every paint. This can
   // cause content JS to run, so must live outside |nojs|.
   auto createCheckpoint = MakeScopeExit([=]() {
-      if (recordreplay::IsRecordingOrReplaying()) {
-        recordreplay::CreateCheckpoint();
-      }
+      recordreplay::CreateCheckpoint();
     });
 
   Maybe<js::AutoAssertNoContentJS> nojs;

--- a/toolkit/recordreplay/JSControl.h
+++ b/toolkit/recordreplay/JSControl.h
@@ -34,6 +34,9 @@ void SendRecordingFinished();
 // Make sure the UI process is notified if the recording is unusable.
 void MaybeSendRecordingUnusable();
 
+// Notify the UI process that recording is unsupported on this machine.
+void SendRecordingUnsupported(const char* aReason);
+
 }  // namespace js
 }  // namespace recordreplay
 }  // namespace mozilla


### PR DESCRIPTION
…s #336

This is kind of tricky because the content process needs to act like it is recording in order to report that recording is unsupported to the UI process.  It would be great if we could get to the point where we can have a test for this, but that will require a more sophisticated way of testing the browser than we are able to deal with at the moment.