### PR TITLE
Replay telemetry for tab crashes.

### DIFF
--- a/browser/base/content/tabbrowser.js
+++ b/browser/base/content/tabbrowser.js
@@ -29,6 +29,11 @@
         "UrlbarProviderOpenTabs",
         "resource:///modules/UrlbarProviderOpenTabs.jsm"
       );
+      ChromeUtils.defineModuleGetter(
+        this,
+        "ReplayTelemetry",
+        "resource://devtools/server/actors/replay/telemetry.js"
+      );
 
       if (AppConstants.MOZ_CRASHREPORTER) {
         ChromeUtils.defineModuleGetter(
@@ -5530,6 +5535,7 @@
         if (!event.isTrusted) {
           return;
         }
+        ReplayTelemetry.pingTelemetry("browser", "crash");
 
         let browser = event.originalTarget;
 


### PR DESCRIPTION
Right now no information about the crash itself is sent: just a ping indicating that a crash occurred.  It doesn't seem like crash data or other info is available at this point - if I wanted to throw in a reason or other info I think we'd need to look elsewhere in the crash handling code to send this message.

But for now, this should do the trick.

The only remaining doubt I have is whether this code is invoked right after a tab crash (when the crashed tab content page is shown), or whether it can be invoked multiple times for the same crash.