### PR TITLE
Add replay:record handler

### DIFF
--- a/toolkit/mozapps/handling/ContentDispatchChooser.jsm
+++ b/toolkit/mozapps/handling/ContentDispatchChooser.jsm
@@ -8,6 +8,9 @@ const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 const { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );
+const { setTimeout } = ChromeUtils.import(
+  "resource://gre/modules/Timer.jsm"
+);
 
 const DIALOG_URL_APP_CHOOSER =
   "chrome://mozapps/content/handling/appChooser.xhtml";
@@ -253,8 +256,8 @@ const replaySchemeMap = {
     if (!target) return;
 
     const browser = browsingContext.topFrameElement;
+    const tabbrowser = browser.getTabBrowser();
     if (newtab) {
-      const tabbrowser = browser.getTabBrowser();
       const currentTabIndex = tabbrowser.visibleTabs.indexOf(tabbrowser.selectedTab);
       const tab = tabbrowser.addTab(
         target,
@@ -262,7 +265,7 @@ const replaySchemeMap = {
       );
       tabbrowser.selectedTab = tab;
     } else {
-      browser.loadURI(target, {
+      tabbrowser.loadURI(target, {
         triggeringPrincipal: principal
       });
     }

--- a/toolkit/mozapps/handling/ContentDispatchChooser.jsm
+++ b/toolkit/mozapps/handling/ContentDispatchChooser.jsm
@@ -267,7 +267,9 @@ const replaySchemeMap = {
       });
     }
 
-    toggleRecording(browser.ownerDocument.defaultView.gBrowser.selectedBrowser);
+    new Promise(resolve => setTimeout(resolve, 500)).then(() => {
+      toggleRecording(browser.ownerDocument.defaultView.gBrowser.selectedBrowser);
+    });
   }
 };
 


### PR DESCRIPTION
## Summary

Adds support for `record` which accepts two query parameters:
* `url` - the url to load in the new tab
* `newtab` - optional parameter to open in a new tab.

## Notes

Decided to go with `replay:record` instead of `replay:newtab` because opening a new tab isn't unique to Replay but recording is. Adding the `newtab` param would be useful in our demo scenario but would be optional for other use cases (e.g. an OSS team could include a direct link for recording their sampler for bugs where the tab isn't relevant).

Closes #496 