### PR TITLE
Ping telemetry when expiring timers in browser.

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -315,7 +315,13 @@ if (ReplayAuth.hasOriginalApiKey()) {
       return;
     }
 
-    gExpirationTimer = setTimeout(clearUserToken, timeToExpiration);
+    gExpirationTimer = setTimeout(
+      () => {
+        pingTelemetry("browser", "auth-expired");
+        clearUserToken();
+      },
+      timeToExpiration
+    );
 
     setenv("RECORD_REPLAY_API_KEY", token);
     setAccessToken(token);


### PR DESCRIPTION
This doesn't fix the stale authentication issue, but at least gives us some telemetry to try to look for when we run into the issue.