### PR TITLE
Open new signin tab when not on replay site

### DIFF
--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1478,7 +1478,12 @@ function createRecordingButton() {
       const url = "https://app.replay.io/?signin=true";
       const options = { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() };
 
-      if (getRecordingState(gBrowser.selectedBrowser) === RecordingState.READY) {
+      // open a new tab to authenticate if not on a replay (or auth0 replay) host
+      const host = gBrowser.selectedBrowser.documentURI.host;
+      if (getRecordingState(gBrowser.selectedBrowser) === RecordingState.READY && (
+        /(\.|^)replay.io$/.test(host) ||
+        "webreplay.us.auth0.com" === host
+      )) {
         gBrowser.loadURI(url, options);
       } else {
         gBrowser.selectedTab = gBrowser.addTab(url, options);


### PR DESCRIPTION
Opens the signin page in a new tab when the user is not on a replay site (*.replay.io, or the auth0 signin page) so they don't lose their place.

Partial credit answer to #462 