### PR TITLE
Add spinner for dark theme

### DIFF
--- a/browser/themes/shared/toolbarbutton-icons.inc.css
+++ b/browser/themes/shared/toolbarbutton-icons.inc.css
@@ -294,6 +294,10 @@ toolbar[brighttext] {
   animation: spinner 1s linear infinite reverse;
 }
 
+html[lwthemetextcolor="bright"] #record-button.waiting {
+  background-image: url("chrome://devtools/skin/images/command-record-wait-dark.svg");
+}
+
 #record-button.hidden {
   display: none !important;
 }

--- a/devtools/client/jar.mn
+++ b/devtools/client/jar.mn
@@ -283,6 +283,7 @@ devtools.jar:
     skin/images/command-signin-fill.svg (themes/images/command-signin-fill.svg)
     skin/images/command-record-fill.svg (themes/images/command-record-fill.svg)
     skin/images/command-record-wait.svg (themes/images/command-record-wait.svg)
+    skin/images/command-record-wait-dark.svg (themes/images/command-record-wait-dark.svg)
     skin/images/command-stop-fill.svg (themes/images/command-stop-fill.svg)
     skin/images/command-pick.svg (themes/images/command-pick.svg)
     skin/images/command-pick-accessibility.svg (themes/images/command-pick-accessibility.svg)

--- a/devtools/client/themes/images/command-record-wait-dark.svg
+++ b/devtools/client/themes/images/command-record-wait-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <circle style="opacity: 0.25;" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+  <path style="opacity: 0.75;" fill="#ffefe6" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+</svg>


### PR DESCRIPTION
Updates colors of the existing spinner and clone the image for dark theme with a lighter color

![light-spinner](https://user-images.githubusercontent.com/788456/135357479-0e426763-bf2d-4e95-a171-9432a4afbdab.gif)
![dark-spinner](https://user-images.githubusercontent.com/788456/135357481-b8f7ab79-6b4e-4ca1-96b5-4892fe0e2013.gif)

