### PR TITLE
Add user data to submitted crash reports.

### DIFF
--- a/toolkit/crashreporter/CrashSubmit.jsm
+++ b/toolkit/crashreporter/CrashSubmit.jsm
@@ -9,6 +9,9 @@ const { FileUtils } = ChromeUtils.import(
 const { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );
+const ReplayAuth = ChromeUtils.import(
+  "resource://devtools/server/actors/replay/auth.js"
+);
 XPCOMUtils.defineLazyGlobalGetters(this, [
   "File",
   "FormData",
@@ -224,9 +227,14 @@ Submitter.prototype = {
       serverURL = envOverride;
     }
 
+    // fetch the user info to send in `Authorization` header.
+    const auth = ReplayAuth.getOriginalApiKey() || ReplayAuth.getReplayUserToken();
+
     let xhr = new XMLHttpRequest();
     xhr.open("POST", serverURL, true);
-
+    if (auth) {
+      xhr.setRequestHeader("Authorization", `Bearer ${auth}`);
+    }
     let formData = new FormData();
 
     // When submitting Record Replay crash reports, only include keys of particular


### PR DESCRIPTION
This uses the same approach as the telemetry server, where we add an `Authorization` header with the encoded user token.  Needs server work to extract the user info and add it to whatever logs get sent out with the crash so we can associate them.

@bhackett1024 I found the crash server url under replay.io that's being contacted to submit these.  Where's the code that services those requests in our codebase?