### PR TITLE
browser: set Win32 Metadata

### DIFF
--- a/browser/app/module.ver
+++ b/browser/app/module.ver
@@ -1,5 +1,5 @@
-WIN32_MODULE_COMPANYNAME=Mozilla Corporation
-WIN32_MODULE_COPYRIGHT=©Firefox and Mozilla Developers; available under the MPL 2 license.
+WIN32_MODULE_COMPANYNAME=RecordReplay, Inc.
+WIN32_MODULE_COPYRIGHT=ï¿½RecordReplay and RecordReplay Developers; available under the MPL 2 license.
 WIN32_MODULE_PRODUCTVERSION=@MOZ_APP_WINVERSION@
 WIN32_MODULE_PRODUCTVERSION_STRING=@MOZ_APP_VERSION@
 WIN32_MODULE_TRADEMARKS=Firefox is a Trademark of The Mozilla Foundation.


### PR DESCRIPTION
Prior to this if you right clicked on the Windows executable, went to
properties, and then details you'd see Mozilla/Firefox references.