### PR TITLE
Add overlay to disable dev tools while recording

### DIFF
--- a/devtools/client/framework/toolbox.xhtml
+++ b/devtools/client/framework/toolbox.xhtml
@@ -23,6 +23,10 @@
   <script src="chrome://devtools/content/framework/toolbox-init.js"/>
 
   <vbox id="toolbox-container" flex="1" role="group">
+    <!-- [Replay] Add overlay to disable devtools while recording -->
+    <div xmlns="http://www.w3.org/1999/xhtml" id="recording-overlay" hidden="true">
+      <li>Developer Tools are disabled while recording.</li>
+    </div>
     <div xmlns="http://www.w3.org/1999/xhtml" id="toolbox-error-mount"/>
     <div xmlns="http://www.w3.org/1999/xhtml" id="toolbox-notificationbox"/>
     <div xmlns="http://www.w3.org/1999/xhtml" id="toolbox-toolbar-mount"

--- a/devtools/client/themes/toolbox.css
+++ b/devtools/client/themes/toolbox.css
@@ -547,3 +547,46 @@
   background-color: var(--theme-toolbar-hover);
   z-index: 1;
 }
+
+/* [Replay] */
+
+/* Let the component gain focus when a click hits an empty area */
+#toolbox-container {
+  position: relative;
+}
+
+#recording-overlay {
+  position: absolute;
+  z-index: 999;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-size: 24pt;
+  font-weight: bold;
+}
+
+#recording-overlay[hidden="true"] {
+  display: none;
+}
+
+#recording-overlay::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: var(--theme-toolbar-background);
+  opacity: 0.6;
+  z-index: -1;
+}
+
+#recording-overlay li {
+  color: #7e6c8f;
+  list-style-image: url("chrome://global/skin/icons/replay-logo-light.svg");
+}

--- a/devtools/client/themes/toolbox.css
+++ b/devtools/client/themes/toolbox.css
@@ -582,7 +582,7 @@
   bottom: 0;
   left: 0;
   background-color: var(--theme-toolbar-background);
-  opacity: 0.6;
+  opacity: 0.8;
   z-index: -1;
 }
 


### PR DESCRIPTION
Adds an overlay to disable devtools interactions while recording. Closes #546 

https://user-images.githubusercontent.com/788456/138174375-e83f8023-6f85-427b-bc8b-c6341a3d55ad.mp4

