### PR TITLE
Fix sign in button to display when auth token expires

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -287,7 +287,14 @@ class CommandError extends Error {
 const gRecordingCreateWaiters = [];
 
 function isLoggedIn() {
-  return !!ReplayAuth.getReplayUserToken() || ReplayAuth.hasOriginalApiKey();
+  const token = ReplayAuth.getReplayUserToken();
+  if (token) {
+    const expiration = ReplayAuth.tokenExpiration(token);
+
+    return expiration && expiration > Date.now();
+  }
+
+  return !!ReplayAuth.hasOriginalApiKey();
 }
 
 async function saveRecordingToken(token) {
@@ -320,6 +327,7 @@ if (ReplayAuth.hasOriginalApiKey()) {
       return;
     }
 
+    const payload = ReplayAuth.tokenInfo(token);
     const expiration = ReplayAuth.tokenExpiration(token);
     if (typeof expiration !== "number") {
       ChromeUtils.recordReplayLog(`InvalidJWTExpiration`);
@@ -329,13 +337,15 @@ if (ReplayAuth.hasOriginalApiKey()) {
 
     const timeToExpiration = expiration - Date.now();
     if (timeToExpiration <= 0) {
+      // TODO (ryanjduffy): fetch() isn't defined yet so this fails
+      // pingTelemetry("browser", "auth-expired", {expiration, authId: payload.sub});
       clearUserToken();
       return;
     }
 
     gExpirationTimer = setTimeout(
       () => {
-        pingTelemetry("browser", "auth-expired");
+        pingTelemetry("browser", "auth-expired", {expiration, authId: payload.sub});
         clearUserToken();
       },
       timeToExpiration

--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -337,8 +337,7 @@ if (ReplayAuth.hasOriginalApiKey()) {
 
     const timeToExpiration = expiration - Date.now();
     if (timeToExpiration <= 0) {
-      // TODO (ryanjduffy): fetch() isn't defined yet so this fails
-      // pingTelemetry("browser", "auth-expired", {expiration, authId: payload.sub});
+      pingTelemetry("browser", "auth-expired", {expiration, authId: payload.sub});
       clearUserToken();
       return;
     }

--- a/devtools/server/actors/replay/telemetry.js
+++ b/devtools/server/actors/replay/telemetry.js
@@ -20,17 +20,20 @@ function pingTelemetry(source, name, data) {
   );
   const browserSettings = { usePreallocated: !disablePreallocated };
 
-  fetch(url, {
-    method: 'POST',
-    headers: auth ? { Authorization: `Bearer ${auth}` } : undefined,
-    body: JSON.stringify({
-      ...data,
-      event: 'Gecko',
-      build: Services.appinfo.appBuildID,
-      ts: Date.now(),
-      source,
-      name,
-      browserSettings,
-    })
-  }).catch(console.error);
+  const xhr = new XMLHttpRequest();
+  xhr.open("POST", url);
+  if (auth) {
+    xhr.setRequestHeader("Authorization", `Bearer ${auth}`);
+  }
+  xhr.send(JSON.stringify({
+    ...data,
+    event: 'Gecko',
+    build: Services.appinfo.appBuildID,
+    ts: Date.now(),
+    source,
+    name,
+    browserSettings,
+  }));
+
+  xhr.onerror = console.error;
 }


### PR DESCRIPTION
* Changes `isLoggedIn` to check expiration date of token
* Changes `pingTelemetry` to use `XMLHttpRequest` because `fetch()` isn't always available but XHR seems to be

Verified by creating a new auth0 endpoint with a 60 second token life to test session expiration both when the browser is open and when it's closed.