### PR TITLE
Mark nodes to be ignored by the node picker (backend#3197)

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -2303,7 +2303,7 @@ function DOM_getAllBoundingClientRects() {
       if (left >= right || top >= bottom) {
         return null;
       }
-      return {
+      const v = {
         node: id,
         rect: [
           elem.left + left,
@@ -2312,6 +2312,13 @@ function DOM_getAllBoundingClientRects() {
           elem.top + bottom,
         ],
       };
+      if (elem.style?.getPropertyValue("visibility") === "hidden") {
+        v.visibility = "hidden";
+      }
+      if (elem.style?.getPropertyValue("pointer-events") === "none") {
+        v.pointerEvents = "none";
+      }
+      return v;
     })
     .filter((v) => !!v);
 


### PR DESCRIPTION
This marks nodes with CSS properties `visibility: hidden` or `pointer-events: none` as non-interactive, so that they can be ignored by the devtools' node picker.
Requires RecordReplay/backend#3342