### PR TITLE
Hide unsupported notification on finished / unusable

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -778,6 +778,7 @@ function handleRecordingStarted(pmm) {
     // Log the reason so we can see in our CI logs when something went wrong.
     console.error("Unstable recording: " + data.why);
     const browser = getBrowser();
+    hideUnsupportedFeatureNotification(browser);
 
     const url = getViewURL('/browser/error');
     url.searchParams.set("message", data.why);
@@ -793,6 +794,8 @@ function handleRecordingStarted(pmm) {
     try {
       const browser = getBrowser();
       let url;
+
+      hideUnsupportedFeatureNotification(browser);
 
       // When the submitTestRecordings pref is set we don't load the viewer,
       // but show a simple page that the recording was submitted, to make things
@@ -835,10 +838,7 @@ function handleRecordingStarted(pmm) {
 }
 
 function showUnsupportedFeatureNotification(browser, feature, issueNumber) {
-  // FIXME how do we get from the browser to the associated window?
-  const window = Services.wm.getMostRecentWindow("navigator:browser");
-
-  const notificationBox = window.gHighPriorityNotificationBox;
+  const notificationBox = browser.ownerGlobal.gHighPriorityNotificationBox;
   let notification = notificationBox.getNotificationWithValue(
     "unsupported-feature"
   );
@@ -860,6 +860,17 @@ function showUnsupportedFeatureNotification(browser, feature, issueNumber) {
       }
     }],
   );
+}
+
+function hideUnsupportedFeatureNotification(browser) {
+  const notificationBox = browser.ownerGlobal.gHighPriorityNotificationBox;
+  const notification = notificationBox.getNotificationWithValue(
+    "unsupported-feature"
+  );
+
+  if (notification) {
+    notificationBox.removeNotification(notification)
+  }
 }
 
 function uploadSourceMap(


### PR DESCRIPTION
Hides the unsupported notification when recording completes / fails

This doesn't yet restrict the notification to only the tab for the error but it's a start!

Relates to #567 