### PR TITLE
Limit unsupported feature notification to current window

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -849,7 +849,7 @@ function handleRecordingStarted(pmm) {
 }
 
 function showUnsupportedFeatureNotification(browser, feature, issueNumber) {
-  const notificationBox = browser.ownerGlobal.gHighPriorityNotificationBox;
+  const notificationBox = browser.getTabBrowser().getNotificationBox(browser);
   let notification = notificationBox.getNotificationWithValue(
     "unsupported-feature"
   );
@@ -874,7 +874,7 @@ function showUnsupportedFeatureNotification(browser, feature, issueNumber) {
 }
 
 function hideUnsupportedFeatureNotification(browser) {
-  const notificationBox = browser.ownerGlobal.gHighPriorityNotificationBox;
+  const notificationBox = browser.getTabBrowser().getNotificationBox(browser);
   const notification = notificationBox.getNotificationWithValue(
     "unsupported-feature"
   );


### PR DESCRIPTION
Push the notification to the tab-specific notification bar rather than the browser-global notification bar. Still remove the notification when the recording completes.


https://user-images.githubusercontent.com/788456/139513835-856a80e9-cf4a-4301-be57-227817c38491.mp4



