### PR TITLE
Add diagnostics for backend issue 3145

### DIFF
--- a/gfx/layers/client/ClientTiledPaintedLayer.cpp
+++ b/gfx/layers/client/ClientTiledPaintedLayer.cpp
@@ -444,7 +444,7 @@ void ClientTiledPaintedLayer::EndPaint() {
 void ClientTiledPaintedLayer::RenderLayer() {
   // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
   if (recordreplay::HasDivergedFromRecording()) {
-    recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer %d %d %d %d",
+    recordreplay::PrintLog("Diverged ClientTiledPaintedLayer::RenderLayer %d %d %d %d",
                            mVisibleRegion.GetBounds().ToUnknownRect().x,
                            mVisibleRegion.GetBounds().ToUnknownRect().y,
                            mVisibleRegion.GetBounds().ToUnknownRect().width,
@@ -532,7 +532,7 @@ void ClientTiledPaintedLayer::RenderLayer() {
     EndPaint();
     // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
     if (recordreplay::HasDivergedFromRecording()) {
-      recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #1");
+      recordreplay::PrintLog("Diverged ClientTiledPaintedLayer::RenderLayer Done #1");
     }
     return;
   }
@@ -541,7 +541,7 @@ void ClientTiledPaintedLayer::RenderLayer() {
     ClientManager()->SetTransactionIncomplete();
     // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
     if (recordreplay::HasDivergedFromRecording()) {
-      recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #2");
+      recordreplay::PrintLog("Diverged ClientTiledPaintedLayer::RenderLayer Done #2");
     }
     return;
   }
@@ -553,7 +553,7 @@ void ClientTiledPaintedLayer::RenderLayer() {
     if (mPaintData.mPaintFinished) {
       // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
       if (recordreplay::HasDivergedFromRecording()) {
-        recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #3");
+        recordreplay::PrintLog("Diverged ClientTiledPaintedLayer::RenderLayer Done #3");
       }
       return;
     }
@@ -606,7 +606,7 @@ void ClientTiledPaintedLayer::RenderLayer() {
       ClientManager()->SetRepeatTransaction();
       // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
       if (recordreplay::HasDivergedFromRecording()) {
-        recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #4");
+        recordreplay::PrintLog("Diverged ClientTiledPaintedLayer::RenderLayer Done #4");
       }
       return;
     }
@@ -617,7 +617,7 @@ void ClientTiledPaintedLayer::RenderLayer() {
     EndPaint();
     // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
     if (recordreplay::HasDivergedFromRecording()) {
-      recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #5");
+      recordreplay::PrintLog("Diverged ClientTiledPaintedLayer::RenderLayer Done #5");
     }
     return;
   }
@@ -635,7 +635,7 @@ void ClientTiledPaintedLayer::RenderLayer() {
     mPaintData.mPaintFinished = false;
     // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
     if (recordreplay::HasDivergedFromRecording()) {
-      recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #6");
+      recordreplay::PrintLog("Diverged ClientTiledPaintedLayer::RenderLayer Done #6");
     }
     return;
   }
@@ -653,7 +653,7 @@ void ClientTiledPaintedLayer::RenderLayer() {
       ClientManager()->SetRepeatTransaction();
     // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
       if (recordreplay::HasDivergedFromRecording()) {
-        recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #7");
+        recordreplay::PrintLog("Diverged ClientTiledPaintedLayer::RenderLayer Done #7");
       }
       return;
     }
@@ -665,7 +665,7 @@ void ClientTiledPaintedLayer::RenderLayer() {
 
   // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
   if (recordreplay::HasDivergedFromRecording()) {
-    recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #8");
+    recordreplay::PrintLog("Diverged ClientTiledPaintedLayer::RenderLayer Done #8");
   }
 }
 

--- a/gfx/layers/client/ClientTiledPaintedLayer.cpp
+++ b/gfx/layers/client/ClientTiledPaintedLayer.cpp
@@ -442,6 +442,15 @@ void ClientTiledPaintedLayer::EndPaint() {
 }
 
 void ClientTiledPaintedLayer::RenderLayer() {
+  // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+  if (recordreplay::HasDivergedFromRecording()) {
+    recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer %d %d %d %d",
+                           mVisibleRegion.GetBounds().ToUnknownRect().x,
+                           mVisibleRegion.GetBounds().ToUnknownRect().y,
+                           mVisibleRegion.GetBounds().ToUnknownRect().width,
+                           mVisibleRegion.GetBounds().ToUnknownRect().height);
+  }
+
   if (!ClientManager()->IsRepeatTransaction()) {
     // Only paint the mask layers on the first transaction.
     RenderMaskLayers(this);
@@ -521,11 +530,19 @@ void ClientTiledPaintedLayer::RenderLayer() {
   invalidRegion.Sub(neededRegion, GetValidRegion());
   if (invalidRegion.IsEmpty()) {
     EndPaint();
+    // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+    if (recordreplay::HasDivergedFromRecording()) {
+      recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #1");
+    }
     return;
   }
 
   if (!callback) {
     ClientManager()->SetTransactionIncomplete();
+    // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+    if (recordreplay::HasDivergedFromRecording()) {
+      recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #2");
+    }
     return;
   }
 
@@ -534,6 +551,10 @@ void ClientTiledPaintedLayer::RenderLayer() {
     // can do the paint.
     BeginPaint();
     if (mPaintData.mPaintFinished) {
+      // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+      if (recordreplay::HasDivergedFromRecording()) {
+        recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #3");
+      }
       return;
     }
 
@@ -583,6 +604,10 @@ void ClientTiledPaintedLayer::RenderLayer() {
       // There is still more high-res stuff to paint, so we're not
       // done yet. A subsequent transaction will take care of this.
       ClientManager()->SetRepeatTransaction();
+      // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+      if (recordreplay::HasDivergedFromRecording()) {
+        recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #4");
+      }
       return;
     }
   }
@@ -590,6 +615,10 @@ void ClientTiledPaintedLayer::RenderLayer() {
   // If there is nothing to draw in low-precision, then we're done.
   if (lowPrecisionInvalidRegion.IsEmpty()) {
     EndPaint();
+    // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+    if (recordreplay::HasDivergedFromRecording()) {
+      recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #5");
+    }
     return;
   }
 
@@ -604,6 +633,10 @@ void ClientTiledPaintedLayer::RenderLayer() {
     ClientManager()->SetRepeatTransaction();
     mPaintData.mLowPrecisionPaintCount = 1;
     mPaintData.mPaintFinished = false;
+    // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+    if (recordreplay::HasDivergedFromRecording()) {
+      recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #6");
+    }
     return;
   }
 
@@ -618,6 +651,10 @@ void ClientTiledPaintedLayer::RenderLayer() {
       // There is still more low-res stuff to paint, so we're not
       // done yet. A subsequent transaction will take care of this.
       ClientManager()->SetRepeatTransaction();
+    // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+      if (recordreplay::HasDivergedFromRecording()) {
+        recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #7");
+      }
       return;
     }
   }
@@ -625,6 +662,11 @@ void ClientTiledPaintedLayer::RenderLayer() {
   // If we get here, we've done all the high- and low-precision
   // paints we wanted to do, so we can finish the paint and chill.
   EndPaint();
+
+  // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+  if (recordreplay::HasDivergedFromRecording()) {
+    recordreplay::PrintLog("ClientTiledPaintedLayer::RenderLayer Done #8");
+  }
 }
 
 bool ClientTiledPaintedLayer::IsOptimizedFor(

--- a/layout/painting/FrameLayerBuilder.cpp
+++ b/layout/painting/FrameLayerBuilder.cpp
@@ -7046,7 +7046,7 @@ void FrameLayerBuilder::PaintItems(std::vector<AssignedDisplayItem>& aItems,
 
     // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
     if (recordreplay::HasDivergedFromRecording()) {
-      recordreplay::PrintLog("FrameLayerBuilder::PaintItems ITEM %d %d %d %d PAINTED %d %d %d %d",
+      recordreplay::PrintLog("Diverged FrameLayerBuilder::PaintItems ITEM %d %d %d %d PAINTED %d %d %d %d",
                              (int)visibleRect.x,
                              (int)visibleRect.y,
                              (int)visibleRect.width,
@@ -7186,7 +7186,7 @@ void FrameLayerBuilder::PaintItems(std::vector<AssignedDisplayItem>& aItems,
 
     // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
     if (recordreplay::HasDivergedFromRecording()) {
-      recordreplay::PrintLog("FrameLayerBuilder::PaintItems ITEM_START %s",
+      recordreplay::PrintLog("Diverged FrameLayerBuilder::PaintItems ITEM_START %s",
                              paintedItem->Name());
     }
 
@@ -7199,7 +7199,7 @@ void FrameLayerBuilder::PaintItems(std::vector<AssignedDisplayItem>& aItems,
 
     // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
     if (recordreplay::HasDivergedFromRecording()) {
-      recordreplay::PrintLog("FrameLayerBuilder::PaintItems ITEM_DONE");
+      recordreplay::PrintLog("Diverged FrameLayerBuilder::PaintItems ITEM_DONE");
     }
   }
 
@@ -7272,7 +7272,7 @@ void FrameLayerBuilder::DrawPaintedLayer(PaintedLayer* aLayer,
                                          void* aCallbackData) {
   // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
   if (recordreplay::HasDivergedFromRecording()) {
-    recordreplay::PrintLog("FrameLayerBuilder::DrawPaintedLayer DRAW %d %d %d %d DIRTY %d %d %d %d",
+    recordreplay::PrintLog("Diverged FrameLayerBuilder::DrawPaintedLayer DRAW %d %d %d %d DIRTY %d %d %d %d",
                            aRegionToDraw.GetBounds().ToUnknownRect().x,
                            aRegionToDraw.GetBounds().ToUnknownRect().y,
                            aRegionToDraw.GetBounds().ToUnknownRect().width,

--- a/layout/painting/FrameLayerBuilder.cpp
+++ b/layout/painting/FrameLayerBuilder.cpp
@@ -7044,6 +7044,19 @@ void FrameLayerBuilder::PaintItems(std::vector<AssignedDisplayItem>& aItems,
 
     const nsRect paintRect = visibleRect.Intersect(boundRect);
 
+    // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+    if (recordreplay::HasDivergedFromRecording()) {
+      recordreplay::PrintLog("FrameLayerBuilder::PaintItems ITEM %d %d %d %d PAINTED %d %d %d %d",
+                             (int)visibleRect.x,
+                             (int)visibleRect.y,
+                             (int)visibleRect.width,
+                             (int)visibleRect.height,
+                             (int)paintRect.x,
+                             (int)paintRect.y,
+                             (int)paintRect.width,
+                             (int)paintRect.height);
+    }
+
     if (paintRect.IsEmpty() || emptyEffectLevel > 0) {
       // In order for this branch to be hit, either this item has an empty paint
       // rect and nothing would be drawn, or an effect marker before this
@@ -7171,11 +7184,22 @@ void FrameLayerBuilder::PaintItems(std::vector<AssignedDisplayItem>& aItems,
     }
 #endif
 
+    // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+    if (recordreplay::HasDivergedFromRecording()) {
+      recordreplay::PrintLog("FrameLayerBuilder::PaintItems ITEM_START %s",
+                             paintedItem->Name());
+    }
+
     if (itemPaintsOwnClip) {
       MOZ_ASSERT(itemClip);
       paintedItem->PaintWithClip(aBuilder, aContext, *itemClip);
     } else {
       paintedItem->Paint(aBuilder, aContext);
+    }
+
+    // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+    if (recordreplay::HasDivergedFromRecording()) {
+      recordreplay::PrintLog("FrameLayerBuilder::PaintItems ITEM_DONE");
     }
   }
 
@@ -7246,6 +7270,19 @@ void FrameLayerBuilder::DrawPaintedLayer(PaintedLayer* aLayer,
                                          DrawRegionClip aClip,
                                          const nsIntRegion& aRegionToInvalidate,
                                          void* aCallbackData) {
+  // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+  if (recordreplay::HasDivergedFromRecording()) {
+    recordreplay::PrintLog("FrameLayerBuilder::DrawPaintedLayer DRAW %d %d %d %d DIRTY %d %d %d %d",
+                           aRegionToDraw.GetBounds().ToUnknownRect().x,
+                           aRegionToDraw.GetBounds().ToUnknownRect().y,
+                           aRegionToDraw.GetBounds().ToUnknownRect().width,
+                           aRegionToDraw.GetBounds().ToUnknownRect().height,
+                           aDirtyRegion.GetBounds().ToUnknownRect().x,
+                           aDirtyRegion.GetBounds().ToUnknownRect().y,
+                           aDirtyRegion.GetBounds().ToUnknownRect().width,
+                           aDirtyRegion.GetBounds().ToUnknownRect().height);
+  }
+
   DrawTarget& aDrawTarget = *aContext->GetDrawTarget();
 
   AUTO_PROFILER_LABEL("FrameLayerBuilder::DrawPaintedLayer",

--- a/toolkit/recordreplay/Graphics.cpp
+++ b/toolkit/recordreplay/Graphics.cpp
@@ -176,6 +176,10 @@ already_AddRefed<gfx::DrawTarget> DrawTargetForRemoteDrawing(const gfx::IntRect&
   size_t bufferSize = ImageDataSerializer::ComputeRGBBufferSize(size, SurfaceFormat);
 
   if (bufferSize != gDrawTargetBufferSize) {
+    // Diagnostics for https://github.com/RecordReplay/backend/issues/3145
+    if (HasDivergedFromRecording()) {
+      PrintLog("Diverged UPDATE_BUFFER %zu", bufferSize);
+    }
     free(gDrawTargetBuffer);
     gDrawTargetBuffer = malloc(bufferSize);
     gDrawTargetBufferSize = bufferSize;


### PR DESCRIPTION
These diagnostics add logging when painting while diverged from the recording, to see what tiles and display items are being painted when we have black boxes in the result.