### PR TITLE
Handle branches before arguments object assignment when analyzing arg…

### DIFF
--- a/js/src/jit/IonAnalysis.cpp
+++ b/js/src/jit/IonAnalysis.cpp
@@ -3941,7 +3941,19 @@ bool jit::AnalyzeArgumentsUsage(JSContext* cx, JSScript* scriptArg) {
     return false;
   }
 
-  MDefinition* argumentsValue = graph.entryBlock()->getSlot(info.argsObjSlot());
+  MDefinition* argumentsValue = nullptr;
+  for (auto iter = graph.begin(); iter != graph.end(); ++iter) {
+    MBasicBlock* block = *iter;
+    MDefinition* def = block->getSlot(info.argsObjSlot());
+    if (!def->isConstant() ||
+        !def->toConstant()->toJSValue().isUndefined()) {
+      argumentsValue = def;
+      break;
+    }
+  }
+  if (!argumentsValue) {
+    return true;
+  }
 
   bool argumentsContentsObserved = false;
 


### PR DESCRIPTION
…uments usage, fixes #588

This fixes a problem with the optimized arguments analysis in IonMonkey in the presence of record/replay instrumentation.  When there is a branch in the MIR before the arguments object assignment, the analysis looked for uses of the initial undefined value assigned to the arguments object slot.  It didn't find any, and allowed the optimized arguments to be used without considering the actual uses of the arguments object.