### PR TITLE
Add diagnostics and a fix for backend issue 3608

### DIFF
--- a/layout/base/PresShell.cpp
+++ b/layout/base/PresShell.cpp
@@ -8545,6 +8545,9 @@ void PresShell::EventHandler::RecordEventHandlingResponsePerformance(
     return;
   }
 
+  // Diagnostic for https://github.com/RecordReplay/backend/issues/3608
+  recordreplay::RecordReplayAssert("PresShell::EventHandler::RecordEventHandlingResponsePerformance #1");
+
   TimeStamp now = TimeStamp::Now();
   double millis = (now - aEvent->mTimeStamp).ToMilliseconds();
   Telemetry::Accumulate(Telemetry::INPUT_EVENT_RESPONSE_MS, millis);

--- a/layout/base/nsRefreshDriver.cpp
+++ b/layout/base/nsRefreshDriver.cpp
@@ -261,6 +261,9 @@ class RefreshDriverTimer {
   TimeStamp GetIdleDeadlineHint(TimeStamp aDefault) {
     MOZ_ASSERT(NS_IsMainThread());
 
+    // Diagnostic for https://github.com/RecordReplay/backend/issues/3608
+    recordreplay::RecordReplayAssert("RefreshDriverTimer::GetIdleDeadlineHint");
+
     TimeStamp mostRecentRefresh = MostRecentRefresh();
     TimeDuration refreshRate = GetTimerRate();
     TimeStamp idleEnd = mostRecentRefresh + refreshRate;

--- a/widget/cocoa/nsNativeThemeCocoa.mm
+++ b/widget/cocoa/nsNativeThemeCocoa.mm
@@ -227,6 +227,11 @@ static void DrawCellIncludingFocusRing(NSCell* aCell, NSRect aWithFrame, NSView*
 }
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView*)controlView {
+  // Custom objective C messages are not replayed, so we pass through events
+  // while recording to ensure that the recorded calls will be consistent
+  // when replaying.
+  recordreplay::AutoPassThroughThreadEvents pt;
+
   CGContext* cgContext = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
 
   HIThemeTrackDrawInfo tdi;
@@ -269,6 +274,9 @@ static void DrawCellIncludingFocusRing(NSCell* aCell, NSRect aWithFrame, NSView*
 @implementation SearchFieldCellWithFocusRing
 
 - (void)drawWithFrame:(NSRect)rect inView:(NSView*)controlView {
+  // Custom objective C messages aren't replayed, see above.
+  recordreplay::AutoPassThroughThreadEvents pt;
+
   [super drawWithFrame:rect inView:controlView];
 
   if (FocusIsDrawnByDrawWithFrame(self)) {


### PR DESCRIPTION
The new assertions here will convert the RecordedCallStackMismatch to a more actionable LinkerMismatch (provided these are the initial places where we had a call stack mismatch, which is hard to tell).  There is an issue where we don't replay the bodies of custom objective C message handlers (we treat all objective C messages as library calls) which caused the objc_msgSend call stack mismatch.