### PR TITLE
Don't trigger build/test tasks for windows/playwright

### DIFF
--- a/.github/actions/build-test/main.js
+++ b/.github/actions/build-test/main.js
@@ -41,31 +41,33 @@ function platformTasks(platform) {
     [buildReplayTask]
   );
 
-  const buildPlaywrightTask = newTask(
-    `Build Gecko/Playwright ${platform}`,
-    {
-      kind: "BuildRuntime",
-      runtime: "geckoPlaywright",
-      revision: playwrightRevision,
-    },
-    platform
-  );
+  const tasks = [buildReplayTask, testReplayTask];
 
-  const testPlaywrightTask = newTask(
-    `Test Gecko/Playwright ${platform}`,
-    {
-      kind: "PlaywrightLiveTests",
-      runtime: "geckoPlaywright",
-      revision: playwrightRevision,
-    },
-    platform,
-    [buildPlaywrightTask]
-  );
+  // Playwright builds aren't yet available for windows.
+  if (platform != "windows") {
+    const buildPlaywrightTask = newTask(
+      `Build Gecko/Playwright ${platform}`,
+      {
+        kind: "BuildRuntime",
+        runtime: "geckoPlaywright",
+        revision: playwrightRevision,
+      },
+      platform
+    );
 
-  return [
-    buildReplayTask,
-    testReplayTask,
-    buildPlaywrightTask,
-    testPlaywrightTask
-  ];
+    const testPlaywrightTask = newTask(
+      `Test Gecko/Playwright ${platform}`,
+      {
+        kind: "PlaywrightLiveTests",
+        runtime: "geckoPlaywright",
+        revision: playwrightRevision,
+      },
+      platform,
+      [buildPlaywrightTask]
+    );
+
+    tasks.push(buildPlaywrightTask, testPlaywrightTask);
+  }
+
+  return tasks;
 }

--- a/.github/actions/release/main.js
+++ b/.github/actions/release/main.js
@@ -30,15 +30,22 @@ function platformTasks(platform) {
     platform
   );
 
-  const releasePlaywrightTask = newTask(
-    `Release Playwright ${platform}`,
-    {
-      kind: "ReleaseRuntime",
-      runtime: "geckoPlaywright",
-      revision: playwrightRevision,
-    },
-    platform
-  );
+  const tasks = [releaseReplayTask];
 
-  return [releaseReplayTask, releasePlaywrightTask];
+  // Playwright builds aren't yet available for windows.
+  if (platform != "windows") {
+    const releasePlaywrightTask = newTask(
+      `Release Playwright ${platform}`,
+      {
+        kind: "ReleaseRuntime",
+        runtime: "geckoPlaywright",
+        revision: playwrightRevision,
+      },
+      platform
+    );
+
+    tasks.push(releasePlaywrightTask);
+  }
+
+  return tasks;
 }


### PR DESCRIPTION
Windows playwright builds aren't supported yet, causing build/test tasks related to this to always fail.  Fixing that shouldn't be terribly hard, but it's even easier to not schedule these tasks we know will fail.