### PR TITLE
Pretend shmem read locks are always unlocked by the compositor when diverged from the recording

### DIFF
--- a/gfx/2d/Factory.cpp
+++ b/gfx/2d/Factory.cpp
@@ -1388,6 +1388,9 @@ bool Factory::ReadbackTexture(uint8_t* aDestData, int32_t aDestStride,
 // static
 void CriticalLogger::OutputMessage(const std::string& aString, int aLevel,
                                    bool aNoNewline) {
+  // Include critical graphics errors in record/replay logs.
+  recordreplay::PrintLog("GraphicsCriticalError %s", aString.c_str());
+
   if (Factory::GetLogForwarder()) {
     Factory::GetLogForwarder()->Log(aString);
   }

--- a/gfx/layers/client/TextureClient.cpp
+++ b/gfx/layers/client/TextureClient.cpp
@@ -1810,6 +1810,13 @@ int32_t ShmemTextureReadLock::GetReadCount() {
   if (!mAllocSuccess) {
     return 0;
   }
+  if (recordreplay::HasDivergedFromRecording()) {
+    // After diverging from the recording, we won't have any read count values
+    // we can replay. Pretend there aren't any other readers so that the shmem
+    // buffer can be written to. This only happens when replaying, when there
+    // truly aren't any other readers.
+    return 1;
+  }
   ShmReadLockInfo* info = GetShmReadLockInfoPtr();
   return recordreplay::RecordReplayValue("ShmemTextureReadLock::GetReadCount",
                                          info->readCount);


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/3145