### PR TITLE
More telemetry to help us investigate auth errors after update.

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -346,14 +346,20 @@ if (ReplayAuth.hasOriginalApiKey()) {
 
     const timeToExpiration = expiration - Date.now();
     if (timeToExpiration <= 0) {
-      pingTelemetry("browser", "auth-expired", {expiration, authId: payload.sub});
+      pingTelemetry("browser", "auth-expired", {
+        expiration,
+        authId: payload.payload.sub,
+      });
       clearUserToken();
       return;
     }
 
     gExpirationTimer = setTimeout(
       () => {
-        pingTelemetry("browser", "auth-expired", {expiration, authId: payload.sub});
+        pingTelemetry("browser", "auth-expired", {
+          expiration,
+          authId: payload.payload.sub,
+        });
         clearUserToken();
       },
       timeToExpiration


### PR DESCRIPTION
Wrote this up with Holger today, who confirmed that these auth issues are reproducible with every browser update.

If we also add IP-tracking to telemetry pings, we can identify and group all the pings together to get some idea of what went on in the browser before/during the error.