### PR TITLE
Use complex line break fallback on windows

### DIFF
--- a/intl/lwbrk/LineBreaker.cpp
+++ b/intl/lwbrk/LineBreaker.cpp
@@ -7,6 +7,7 @@
 
 #include "jisx4051class.h"
 #include "nsComplexBreaker.h"
+#include "nsINode.h"
 #include "nsTArray.h"
 #include "nsUnicodeProperties.h"
 #include "mozilla/ArrayUtils.h"
@@ -1166,4 +1167,18 @@ void LineBreaker::GetJISx4051Breaks(const uint8_t* aChars, uint32_t aLength,
     if (allowBreak) state.NotifyBreakBefore();
     lastClass = cl;
   }
+}
+
+bool RecordReplayMaybeGetComplexLineBreaks(const char16_t* aText, uint32_t aLength,
+                                           uint8_t* aBreakBefore) {
+  if (!mozilla::recordreplay::HasDivergedFromRecording()) {
+    return false;
+  }
+  memset(aBreakBefore, 0, aLength * sizeof(uint8_t));
+  for (size_t i = 1; i < aLength; i++) {
+    if (mozilla::dom::IsSpaceCharacter(aText[i - 1]) && !mozilla::dom::IsSpaceCharacter(aText[i])) {
+      aBreakBefore[i] = true;
+    }
+  }
+  return true;
 }

--- a/intl/lwbrk/nsComplexBreaker.h
+++ b/intl/lwbrk/nsComplexBreaker.h
@@ -15,4 +15,12 @@
 void NS_GetComplexLineBreaks(const char16_t* aText, uint32_t aLength,
                              uint8_t* aBreakBefore);
 
+// This is used on some platforms when diverged from the recording. In this case
+// system calls made while computing line breaks might not be present in the
+// recording, and may cause the computation to fail. The breaks will be computed
+// without performing system calls by placing breaks at the start of any
+// non-space token which follows some spaces. Returns whether the breaks were filled in.
+bool RecordReplayMaybeGetComplexLineBreaks(const char16_t* aText, uint32_t aLength,
+                                           uint8_t* aBreakBefore);
+
 #endif /* nsComplexBreaker_h__ */

--- a/intl/lwbrk/nsUniscribeBreaker.cpp
+++ b/intl/lwbrk/nsUniscribeBreaker.cpp
@@ -17,6 +17,10 @@ void NS_GetComplexLineBreaks(const char16_t* aText, uint32_t aLength,
                              uint8_t* aBreakBefore) {
   NS_ASSERTION(aText, "aText shouldn't be null");
 
+  if (RecordReplayMaybeGetComplexLineBreaks(aText, aLength, aBreakBefore)) {
+    return;
+  }
+
   int outItems = 0;
   HRESULT result;
   AutoTArray<SCRIPT_ITEM, 64> items;


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/3710

ScriptItemize is called while getting complex line breaks (line breaks within a word I think, not sure).  The system calls for handling this are pretty complicated to handle while diverged from the recording.  On macOS we run into a similar situation, where we have special logic to compute these breaks (incorrectly, but that's not the end of the world) when diverged without calling into the system.  This patch refactors things so we can do the same thing on windows without needing to duplicate the logic.