### PR TITLE
Handle getting complex line breaks on linux when diverged from recording

### DIFF
--- a/intl/lwbrk/nsPangoBreaker.cpp
+++ b/intl/lwbrk/nsPangoBreaker.cpp
@@ -14,6 +14,10 @@ void NS_GetComplexLineBreaks(const char16_t* aText, uint32_t aLength,
                              uint8_t* aBreakBefore) {
   NS_ASSERTION(aText, "aText shouldn't be null");
 
+  if (RecordReplayMaybeGetComplexLineBreaks(aText, aLength, aBreakBefore)) {
+    return;
+  }
+
   memset(aBreakBefore, false, aLength * sizeof(uint8_t));
 
   AutoTArray<PangoLogAttr, 2000> attrBuffer;


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/3736

This is the analogous case to https://github.com/RecordReplay/gecko-dev/pull/605 for linux.