### PR TITLE
Avoid enumerating pointer devices when diverged from the recording

### DIFF
--- a/widget/windows/InputDeviceUtils.cpp
+++ b/widget/windows/InputDeviceUtils.cpp
@@ -37,6 +37,11 @@ void InputDeviceUtils::UnregisterNotification(HDEVNOTIFY aHandle) {
 
 DWORD
 InputDeviceUtils::CountMouseDevices() {
+  // Avoid calling complex system functions while we're diverged from the recording.
+  if (recordreplay::HasDivergedFromRecording()) {
+    return 1;
+  }
+
   HDEVINFO hdev =
       SetupDiGetClassDevs(&GUID_DEVINTERFACE_MOUSE, nullptr, nullptr,
                           DIGCF_DEVICEINTERFACE | DIGCF_PRESENT);


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/3737.  These APIs are pretty complicated to deal with in the record/replay driver when diverged from the recording, so for now it's simpler to avoid enumerating the mouse devices in this case.