### PR TITLE
Disable eval cache when recording/replaying

### DIFF
--- a/js/src/builtin/Eval.cpp
+++ b/js/src/builtin/Eval.cpp
@@ -264,7 +264,11 @@ static bool EvalKernel(JSContext* cx, HandleValue v, EvalType evalType,
 
   EvalScriptGuard esg(cx);
 
-  if (evalType == DIRECT_EVAL && caller.isFunctionFrame()) {
+  if (evalType == DIRECT_EVAL && caller.isFunctionFrame() &&
+      // The eval cache is purged at non-deterministic points during GC, and affects
+      // when the debugger's new script notification fires. Disable the cache when
+      // recording/replaying to avoid this non-determinism.
+      !mozilla::recordreplay::IsRecordingOrReplaying()) {
     esg.lookupInEvalCache(linearStr, callerScript, pc);
   }
 


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/3246

The eval cache is used to avoid doing recompiling eval scripts when the same script is evaluated repeatedly.  This is handy for improving sunspider performance and could be handy I guess on poorly written real websites, but the cache is swept / purged at non-deterministic points related to GC.  The debugger's new script hook only fires on cache misses, and this hook needs to run at deterministic points.  This PR disables the eval cache when recording/replaying to avoid this non-determinism.