### PR TITLE
Add diagnostic for backend issue 3659

### DIFF
--- a/gfx/thebes/gfxHarfBuzzShaper.cpp
+++ b/gfx/thebes/gfxHarfBuzzShaper.cpp
@@ -1360,6 +1360,15 @@ bool gfxHarfBuzzShaper::ShapeText(DrawTarget* aDrawTarget,
                                   gfxShapedText* aShapedText) {
   mUseVerticalPresentationForms = false;
 
+  // Diagnostic for https://github.com/RecordReplay/backend/issues/3659
+  std::string str;
+  for (uint32_t i = 0; i < aLength; i++) {
+    char buf[50];
+    snprintf(buf, sizeof(buf), " %u", aText[i]);
+    str += buf;
+  }
+  recordreplay::RecordReplayAssert("gfxHarfBuzzShaper::ShapeText %s", str.c_str());
+
   if (!Initialize()) {
     return false;
   }


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/3659.  This adds back an assert removed in https://github.com/RecordReplay/backend/issues/2666, but for which we've still seen related mismatches in at least one user recording.