### PR TITLE
Allow invalidating the recording via nsIRemoteTab.finishRecording

### DIFF
--- a/dom/interfaces/base/nsIRemoteTab.idl
+++ b/dom/interfaces/base/nsIRemoteTab.idl
@@ -82,9 +82,10 @@ interface nsIRemoteTab : nsISupports
   void stopApzAutoscroll(in nsViewID aScrollId, in uint32_t aPresShellId);
 
   /**
-   * Flush the current recording with a description.
+   * Finish the recording being made by the current tab. If aInvalidateReason is
+   * specified then the recording will be invalidated with that reason.
    */
-  bool finishRecording();
+  bool finishRecording([optional] in ACString aInvalidateReason);
 
   cenum NavigationType : 8 {
     NAVIGATE_BACK = 0,

--- a/dom/ipc/BrowserHost.cpp
+++ b/dom/ipc/BrowserHost.cpp
@@ -241,11 +241,11 @@ BrowserHost::StopApzAutoscroll(nsViewID aScrollId, uint32_t aPresShellId) {
 
 /* bool finishRecording (); */
 NS_IMETHODIMP
-BrowserHost::FinishRecording(bool* _retval) {
+BrowserHost::FinishRecording(const nsACString& aInvalidateReason, bool* _retval) {
   if (!mRoot) {
     return NS_OK;
   }
-  return GetContentParent()->FinishRecording(_retval);
+  return GetContentParent()->FinishRecording(aInvalidateReason, _retval);
 }
 
 NS_IMETHODIMP

--- a/dom/ipc/ContentChild.cpp
+++ b/dom/ipc/ContentChild.cpp
@@ -3414,8 +3414,12 @@ mozilla::ipc::IPCResult ContentChild::RecvAddDynamicScalars(
   return IPC_OK();
 }
 
-mozilla::ipc::IPCResult ContentChild::RecvFinishRecording() {
-  recordreplay::FinishRecording();
+mozilla::ipc::IPCResult ContentChild::RecvFinishRecording(const nsCString& aInvalidateReason) {
+  if (aInvalidateReason.Length()) {
+    recordreplay::InvalidateRecording(aInvalidateReason.get());
+  } else {
+    recordreplay::FinishRecording();
+  }
   return IPC_OK();
 }
 

--- a/dom/ipc/ContentChild.h
+++ b/dom/ipc/ContentChild.h
@@ -631,7 +631,7 @@ class ContentChild final : public PContentChild,
       const uint32_t& aPluginEpoch, nsTArray<PluginTag>&& aPluginTags,
       nsTArray<FakePluginTag>&& aFakePluginTags);
 
-  mozilla::ipc::IPCResult RecvFinishRecording();
+  mozilla::ipc::IPCResult RecvFinishRecording(const nsCString& aInvalidateReason);
 
   mozilla::ipc::IPCResult RecvCrossProcessRedirect(
       RedirectToRealChannelArgs&& aArgs,

--- a/dom/ipc/ContentParent.cpp
+++ b/dom/ipc/ContentParent.cpp
@@ -1743,7 +1743,7 @@ void ContentParent::ShutDownProcess(ShutDownMethod aMethod) {
   // finish uploading in that case.
   if (IsRecording() && TestEnv("RECORD_ALL_CONTENT")) {
     bool retval;
-    FinishRecording(&retval);
+    FinishRecording(nsCString(), &retval);
   }
 
   // Shutting down by sending a shutdown message works differently than the
@@ -6368,7 +6368,7 @@ bool ContentParent::DeallocPSessionStorageObserverParent(
   return mozilla::dom::DeallocPSessionStorageObserverParent(aActor);
 }
 
-nsresult ContentParent::FinishRecording(bool* aRetval) {
+nsresult ContentParent::FinishRecording(const nsACString& aInvalidateReason, bool* aRetval) {
   if (mRecordingDispatchAddress.IsEmpty() || mRecordingFinished) {
     *aRetval = false;
     return NS_OK;
@@ -6376,7 +6376,7 @@ nsresult ContentParent::FinishRecording(bool* aRetval) {
 
   mRecordingFinished = true;
 
-  Unused << SendFinishRecording();
+  Unused << SendFinishRecording(nsCString(aInvalidateReason));
 
   *aRetval = true;
   return NS_OK;

--- a/dom/ipc/ContentParent.h
+++ b/dom/ipc/ContentParent.h
@@ -1440,7 +1440,7 @@ class ContentParent final
                                const bool& aMinimizeMemoryUsage,
                                const Maybe<FileDescriptor>& aDMDFile) override;
 
-  nsresult FinishRecording(bool* aRetval);
+  nsresult FinishRecording(const nsACString& aInvalidateReason, bool* aRetval);
 
   bool IsRecording() const {
     return mRecordingDispatchAddress.Length() != 0;

--- a/dom/ipc/PContent.ipdl
+++ b/dom/ipc/PContent.ipdl
@@ -877,9 +877,10 @@ child:
     async AddDynamicScalars(DynamicScalarDefinition[] definitions);
 
     /*
-     * Flush the recording and send a description back to this process.
+     * Finish the recording being made by the process. If invalidateReason is
+     * specified then the recording will be invalidated with that reason.
      */
-    async FinishRecording();
+    async FinishRecording(nsCString invalidateReason);
 
     // This message is sent to content processes, and triggers the creation of a
     // new HttpChannelChild that will be connected to the parent channel


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/gecko-dev/issues/622.  I tested this by passing an invalidation reason to the finishRecording() call in connection.js / stopRecording, and the recording was invalidated as expected instead of being saved.