### PR TITLE
Fix invalid return value.

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -1055,7 +1055,9 @@ function collectUnresolvedSourceMapResources(mapText, mapURL, mapBaseURL) {
 
   if (obj.version !== 3) {
     logError("Invalid sourcemap version");
-    return;
+    return {
+      sources: [],
+    };
   }
 
   if (obj.sources != null) {


### PR DESCRIPTION
Every other `return` in this function returns this object structure, but we were missing it here so the callsite could sometimes throw.

Found by the telemetry added due to https://github.com/RecordReplay/backend/issues/3606