### PR TITLE
Fix connection authentication issue (#598)

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -221,8 +221,10 @@ gCommandSocket.onStateChange = state => {
   }
 }
 
+setenv("RECORD_REPLAY_AUTH", null);
 let gTokenChangeCallbacks = null;
 function setAccessToken(token, isAPIKey) {
+  setenv("RECORD_REPLAY_AUTH", token);
   gCommandSocket.setAccessToken(token);
 
   // If we're working with an API key, there's no way for us to get a new
@@ -360,7 +362,6 @@ if (ReplayAuth.hasOriginalApiKey()) {
       timeToExpiration
     );
 
-    setenv("RECORD_REPLAY_API_KEY", token);
     setAccessToken(token);
   }
 

--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -221,6 +221,11 @@ gCommandSocket.onStateChange = state => {
   }
 }
 
+// when the browser restarts itself (usually after an update), the
+// environment variables are retained. We want to ensure that this
+// variable doesn't contain an outdated token, so we clear it here
+// and rely on the initialization code in this file to set it again
+// if an API key or a current token is found.
 setenv("RECORD_REPLAY_AUTH", null);
 let gTokenChangeCallbacks = null;
 function setAccessToken(token, isAPIKey) {

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1463,7 +1463,6 @@ function createRecordingButton() {
       node.refreshStatus();
 
       Services.prefs.addObserver("devtools.recordreplay.user-token", () => {
-        pingTelemetry("browser", "recording-button-refresh-status-on-user-token-change")
         node.refreshStatus();
       });
     },
@@ -1525,55 +1524,27 @@ function openSigninPage(gBrowser) {
 
 function refreshRecordingButton(doc) {
   const node = doc.getElementById("record-button");
-  const refreshed = [];
   if (node) {
     node.refreshStatus();
-    refreshed.push("record-button");
   }
   const signinNode = doc.getElementById("replay-signin-button");
   if (signinNode) {
     signinNode.refreshStatus();
-    refreshed.push("replay-signin-button");
   }
-  return refreshed.join("-and-");
 }
 
-const REFRESH_PING_TELEMETRY_INTERVAL_MS = 5 * 60 * 1000;
-let gLastPingTelemetryForRefresh = Number.NEGATIVE_INFINITY;
 function refreshAllRecordingButtons() {
-  let findRecButton = "not-found";
-  let telemetryData = {};
   try {
     for (const w of Services.wm.getEnumerator("navigator:browser")) {
-      const refreshedButtons = refreshRecordingButton(w.document);
-      if (refreshedButtons) {
-        findRecButton = `found-${refreshedButtons}`;
-      }
+      refreshRecordingButton(w.document);
     }
-  } catch (e) {
-    findRecButton = "threw";
-    telemetryData.message = e.message;
-    telemetryData.stack = e.stack;
-  } finally {
-    const timeDelta = Date.now() - gLastPingTelemetryForRefresh;
-    if (timeDelta > REFRESH_PING_TELEMETRY_INTERVAL_MS) {
-      pingTelemetry(
-        "browser",
-        "refresh-all-recording-buttons",
-        { findRecButton, ...telemetryData }
-      );
-      gLastPingTelemetryForRefresh = Date.now();
-    }
-  }
+  } catch (e) {}
 }
 
 // When state changes which affects the recording buttons, we try to update the
 // buttons immediately, but make sure that the recording button state does not
 // get out of sync with the display state of the button.
-pingTelemetry("browser", "set-interval-refresh-all-recording-buttons");
-setInterval(() => {
-  refreshAllRecordingButtons();
-}, 2000);
+setInterval(refreshAllRecordingButtons, 2000);
 
 async function runTestScript() {
   const script = env.get("RECORD_REPLAY_TEST_SCRIPT");

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -308,6 +308,8 @@ MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
   MOZ_RELEASE_ASSERT(dispatchAddress.isSome());
 
   Maybe<std::string> apiKey;
+  // this environment variable is set by server/actors/replay/connection.js
+  // to contain the API key or user token
   const char* val = getenv("RECORD_REPLAY_AUTH");
   if (val && val[0]) {
     apiKey.emplace(val);

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -308,7 +308,7 @@ MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
   MOZ_RELEASE_ASSERT(dispatchAddress.isSome());
 
   Maybe<std::string> apiKey;
-  const char* val = getenv("RECORD_REPLAY_API_KEY");
+  const char* val = getenv("RECORD_REPLAY_AUTH");
   if (val && val[0]) {
     apiKey.emplace(val);
     // Unsetting the env var will make the variable unavailable via
@@ -317,9 +317,9 @@ MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
     // existed and won't capture it in the recording itself, which
     // is ideal for security.
 #ifdef XP_WIN
-    MOZ_RELEASE_ASSERT(!_putenv("RECORD_REPLAY_API_KEY="));
+    MOZ_RELEASE_ASSERT(!_putenv("RECORD_REPLAY_AUTH="));
 #else
-    MOZ_RELEASE_ASSERT(!unsetenv("RECORD_REPLAY_API_KEY"));
+    MOZ_RELEASE_ASSERT(!unsetenv("RECORD_REPLAY_AUTH"));
 #endif
   }
 


### PR DESCRIPTION
[Some context](https://github.com/RecordReplay/gecko-dev/issues/598#issuecomment-994793969)
With this PR, we use `RECORD_REPLAY_API_KEY` only for receiving an API key from the user, and use `RECORD_REPLAY_AUTH` for the internal communication.
