### PR TITLE
Assert that IPC message contents are consistent when replaying

### DIFF
--- a/ipc/chromium/src/chrome/common/ipc_channel_posix.cc
+++ b/ipc/chromium/src/chrome/common/ipc_channel_posix.cc
@@ -563,9 +563,8 @@ bool Channel::ChannelImpl::ProcessIncomingMessages() {
 bool Channel::ChannelImpl::ProcessOutgoingMessages() {
   // Don't process channel messages after diverging from the recording.
   // We don't need behavior here to match up with the recording process after
-  // divergence, and we have seen crashes when trying to read off the end of
-  // BufferLists in this function. It would be nice to have a better idea of
-  // what is happening here.
+  // divergence, and we'll get confused when different messages are sent when
+  // recording vs. replaying.
   if (mozilla::recordreplay::HasDivergedFromRecording()) {
     return true;
   }

--- a/ipc/glue/MessageLink.cpp
+++ b/ipc/glue/MessageLink.cpp
@@ -133,6 +133,11 @@ void ProcessLink::Open(UniquePtr<Transport> aTransport, MessageLoop* aIOLoop,
 }
 
 void ProcessLink::SendMessage(UniquePtr<Message> msg) {
+  // Check that messages sent over IPC channels have consistent contents when
+  // recording vs. replaying.
+  mozilla::recordreplay::RecordReplayAssert("ProcessLink::SendMessage %d %d %u",
+                                            msg->type(), msg->routing_id(), msg->size());
+
   if (msg->size() > IPC::Channel::kMaximumMessageSize) {
     CrashReporter::AnnotateCrashReport(
         CrashReporter::Annotation::IPCMessageName,


### PR DESCRIPTION
Diagnostic for https://github.com/RecordReplay/backend/issues/3563, though we'll want to leave this new assert in afterwards.