### PR TITLE
Add support for authenticating via user-default browser

### DIFF
--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -6,7 +6,7 @@ const {
   newTask,
 } = require("../utils");
 
-const branchName = process.env.GITHUB_REF_NAME;
+const branchName = getBranchName(process.env.GITHUB_REF);
 console.log("BranchName", branchName);
 
 if (branchName.includes("webreplay-release")) {
@@ -54,4 +54,13 @@ function platformTasks(platform) {
   );
 
   return [buildReplayTask, testReplayTask];
+}
+
+function getBranchName(refName) {
+  // Strip everything after the last "/" from the ref to get the branch name.
+  const index = refName.lastIndexOf("/");
+  if (index == -1) {
+    return refName;
+  }
+  return refName.substring(index + 1);
 }

--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -6,7 +6,7 @@ const {
   newTask,
 } = require("../utils");
 
-const branchName = getBranchName(process.env.GITHUB_REF);
+const branchName = process.env.GITHUB_REF_NAME;
 console.log("BranchName", branchName);
 
 if (branchName.includes("webreplay-release")) {
@@ -54,13 +54,4 @@ function platformTasks(platform) {
   );
 
   return [buildReplayTask, testReplayTask];
-}
-
-function getBranchName(refName) {
-  // Strip everything after the last "/" from the ref to get the branch name.
-  const index = refName.lastIndexOf("/");
-  if (index == -1) {
-    return refName;
-  }
-  return refName.substring(index + 1);
 }

--- a/browser/branding/recordreplay/pref/firefox-branding.js
+++ b/browser/branding/recordreplay/pref/firefox-branding.js
@@ -49,3 +49,6 @@ pref("browser.urlbar.suggest.quicksuggest",         false);
 // Telemetry
 pref('replay.telemetry.url', 'https://telemetry.replay.io');
 pref('replay.telemetry.enabled', true);
+
+// Authentication Flow
+pref('devtools.recordreplay.ext-auth', false);

--- a/devtools/server/actors/replay/api-server.js
+++ b/devtools/server/actors/replay/api-server.js
@@ -28,18 +28,17 @@ function getAPIServer() {
 async function queryAPIServer(query, variables = {}) {
   const token = ReplayAuth.getReplayUserToken() || ReplayAuth.getOriginalApiKey();
 
-  if (!token) {
-    // We shouldn't hit this because the recording button shouldn't be enabled
-    // if the user hasn't authenticated
-    throw new Error("Authentication required");
+  const headers = {
+    "Content-Type": "application/json",
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
   }
 
   const resp = await fetch(getAPIServer(), {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
+    headers,
     body: JSON.stringify({
       query,
       variables

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -120,15 +120,16 @@ let authChannel;
 
 function handleAuthChannelMessage(_id, message, target) {
   const { type } = message;
+  // TODO [ryanjduffy]: Add support for app login to use the browser auth flow
+  // by extending this logic to support a webchannel message from the client
+  // (the app) to request a login which would launch the sign in page in the
+  // user's preferred browser.
   if (type === "connect") {
     deferredAccessToken.promise.then(token => {
       if (authChannel) {
         authChannel.send({ token }, target);
       }
     })
-  // TODO [ryanjduffy]: Add support for app login to use the browser auth flow
-  // } else if (type === "login") {
-  //   openSigninPage();
   } else if ('token' in message) {
     if (!message.token) {
       setReplayRefreshToken(null);

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -217,7 +217,7 @@ function openSigninPage() {
     new Promise((_resolve, reject) => setTimeout(reject, 2 * 60 * 1000)),
     new Promise(async (resolve, reject) => {
       let retries = 0;
-      while (retries < 20) {
+      while (retries < 40) {
         const resp = await queryAPIServer(`
           mutation CloseAuthRequest($key: String!) {
             closeAuthRequest(input: {key: $key}) {
@@ -231,7 +231,7 @@ function openSigninPage() {
 
         if (resp.errors) {
           retries++;
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise(resolve => setTimeout(resolve, 3000));
         } else {
           setReplayRefreshToken(resp.data.closeAuthRequest.token);
           resolve();

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -184,8 +184,14 @@ async function refresh() {
   }
 }
 
+function base64URLEncode(str) {
+  // https://auth0.com/docs/authorization/flows/call-your-api-using-the-authorization-code-flow-with-pkce
+  return str.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
 function openSigninPage() {
-  const key = btoa(Array.from({length: 32}, () => String.fromCodePoint(Math.floor(Math.random() * 256))).join(""))
+  const keyArray = Array.from({length: 32}, () => String.fromCodePoint(Math.floor(Math.random() * 256)));
+  const key = base64URLEncode(btoa(keyArray.join("")));
   const url = Services.io.newURI(`http://localhost:8080/api/browser/auth?key=${key}`);
 
   gExternalProtocolService

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -63,7 +63,7 @@ function getOriginalApiKey() {
 
 function setReplayRefreshToken(token) {
   Services.prefs.setStringPref("devtools.recordreplay.refresh-token", token || "");
-  refresh(token);
+  refresh();
 }
 
 function setReplayUserToken(token) {
@@ -144,7 +144,8 @@ function initializeRecordingWebChannel() {
   }
 }
 
-async function refresh(refreshToken) {
+async function refresh() {
+  const refreshToken = Services.prefs.getStringPref("devtools.recordreplay.refresh-token", "");
   if (!refreshToken) {
     return;
   }
@@ -222,5 +223,5 @@ function openSigninPage() {
 // Init
 (() => {
   initializeRecordingWebChannel();
-  refresh(Services.prefs.getStringPref("devtools.recordreplay.refresh-token", ""));
+  refresh();
 })();

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -8,13 +8,46 @@
 var EXPORTED_SYMBOLS = [
   "hasOriginalApiKey",
   "getOriginalApiKey",
+  "setReplayRefreshToken",
   "setReplayUserToken",
   "getReplayUserToken",
   "tokenInfo",
-  "tokenExpiration"
+  "tokenExpiration",
+  "openSigninPage"
 ];
 
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+const { setTimeout } = ChromeUtils.import("resource://gre/modules/Timer.jsm");
+const { queryAPIServer } = ChromeUtils.import(
+  "resource://devtools/server/actors/replay/api-server.js"
+);
+
+XPCOMUtils.defineLazyServiceGetter(
+  this,
+  "gExternalProtocolService",
+  "@mozilla.org/uriloader/external-helper-app-service;1",
+  Ci.nsIExternalProtocolService
+);
+
+ChromeUtils.defineModuleGetter(
+  this,
+  "WebChannel",
+  "resource://gre/modules/WebChannel.jsm"
+);
+
+XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
+
+function defer() {
+  let resolve, reject;
+  const promise = new Promise(function(res, rej) {
+    resolve = res;
+    reject = rej;
+  });
+  return { resolve, reject, promise };
+};
+
+let deferredAccessToken = defer();
 
 const Env = Cc["@mozilla.org/process/environment;1"].getService(
   Ci.nsIEnvironment
@@ -28,7 +61,17 @@ function getOriginalApiKey() {
   return gOriginalApiKey;
 }
 
+function setReplayRefreshToken(token) {
+  Services.prefs.setStringPref("devtools.recordreplay.refresh-token", token || "");
+  refresh(token);
+}
+
 function setReplayUserToken(token) {
+  if (token) {
+    deferredAccessToken.resolve(token);
+  } else {
+    deferredAccessToken = defer();
+  }
   Services.prefs.setStringPref("devtools.recordreplay.user-token", token || "");
 }
 function getReplayUserToken() {
@@ -66,3 +109,118 @@ function tokenExpiration(token) {
   const exp = userInfo.payload?.exp;
   return typeof exp === "number" ? exp * 1000 : null;
 }
+
+function handleAuthChannelMessage(_id, message, target) {
+  const { type } = message;
+  if (type === "connect") {
+    deferredAccessToken.promise.then(token => {
+      authChannel.send({ token }, target);
+    })
+  // TODO [ryanjduffy]: Add support for app login to use the browser auth flow
+  // } else if (type === "login") {
+  //   openSigninPage();
+  } else if ('token' in message) {
+    if (!message.token) {
+      setReplayRefreshToken(null);
+    }
+    setReplayUserToken(message.token);
+  }
+}
+
+function initializeRecordingWebChannel() {
+  const pageUrl = Services.prefs.getStringPref(
+    "devtools.recordreplay.recordingsUrl"
+  );
+  const localUrl = "http://localhost:8080/";
+
+  registerWebChannel(pageUrl);
+  registerWebChannel(localUrl);
+
+  function registerWebChannel(url) {
+    const urlForWebChannel = Services.io.newURI(url);
+    const authChannel = new WebChannel("record-replay-token", urlForWebChannel);
+
+    authChannel.listen(handleAuthChannelMessage);
+  }
+}
+
+async function refresh(refreshToken) {
+  if (!refreshToken) {
+    return;
+  }
+
+  const resp = await fetch("https://webreplay.us.auth0.com/oauth/token", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({
+      audience: "https://api.replay.io",
+      scope: "openid profile offline_access",
+      grant_type: "refresh_token",
+      client_id: "4FvFnJJW4XlnUyrXQF8zOLw6vNAH1MAo",
+      refresh_token: refreshToken,
+    })
+  });
+
+  const json = await resp.json();
+
+  if (json.error) {
+    // TODO: telemetry
+    setReplayRefreshToken("");
+    setReplayUserToken("");
+    return;
+  }
+
+
+  if (json.access_token) {
+    Services.prefs.setStringPref("devtools.recordreplay.refresh-token", json.refresh_token);
+    setReplayUserToken(json.access_token);
+
+    setTimeout(refresh, json.expires_in * 1000);
+  }
+}
+
+function openSigninPage() {
+  const key = btoa(Array.from({length: 32}, () => String.fromCodePoint(Math.floor(Math.random() * 256))).join(""))
+  const url = Services.io.newURI(`http://localhost:8080/api/browser/auth?key=${key}`);
+
+  gExternalProtocolService
+    .getProtocolHandlerInfo("https")
+    .launchWithURI(url);
+
+  Promise.race([
+    new Promise((_resolve, reject) => setTimeout(reject, 2 * 60 * 1000)),
+    new Promise(async (resolve, reject) => {
+      let retries = 0;
+      while (retries < 20) {
+        const resp = await queryAPIServer(`
+          mutation CloseAuthRequest($key: String!) {
+            closeAuthRequest(input: {key: $key}) {
+              success
+              token
+            }
+          }
+        `, {
+          key
+        });
+
+        if (resp.errors) {
+          retries++;
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        } else {
+          setReplayRefreshToken(resp.data.closeAuthRequest.token);
+          resolve();
+          break;
+        }
+      }
+
+      reject(`Failed to authenticate`);
+    })
+  ]).catch(console.error);
+}
+
+
+// Init
+(() => {
+  initializeRecordingWebChannel();
+  refresh(Services.prefs.getStringPref("devtools.recordreplay.refresh-token", ""));
+})();

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -22,6 +22,9 @@ const { setTimeout } = ChromeUtils.import("resource://gre/modules/Timer.jsm");
 const { queryAPIServer } = ChromeUtils.import(
   "resource://devtools/server/actors/replay/api-server.js"
 );
+const { getenv } = ChromeUtils.import(
+  "resource://devtools/server/actors/replay/env.js"
+);
 
 XPCOMUtils.defineLazyServiceGetter(
   this,
@@ -192,7 +195,8 @@ function base64URLEncode(str) {
 function openSigninPage() {
   const keyArray = Array.from({length: 32}, () => String.fromCodePoint(Math.floor(Math.random() * 256)));
   const key = base64URLEncode(btoa(keyArray.join("")));
-  const url = Services.io.newURI(`http://localhost:8080/api/browser/auth?key=${key}`);
+  const viewHost = getenv("RECORD_REPLAY_VIEW_HOST") || "https://app.replay.io";
+  const url = Services.io.newURI(`${viewHost}/api/browser/auth?key=${key}`);
 
   gExternalProtocolService
     .getProtocolHandlerInfo("https")

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -110,11 +110,15 @@ function tokenExpiration(token) {
   return typeof exp === "number" ? exp * 1000 : null;
 }
 
+let authChannel;
+
 function handleAuthChannelMessage(_id, message, target) {
   const { type } = message;
   if (type === "connect") {
     deferredAccessToken.promise.then(token => {
-      authChannel.send({ token }, target);
+      if (authChannel) {
+        authChannel.send({ token }, target);
+      }
     })
   // TODO [ryanjduffy]: Add support for app login to use the browser auth flow
   // } else if (type === "login") {
@@ -138,7 +142,7 @@ function initializeRecordingWebChannel() {
 
   function registerWebChannel(url) {
     const urlForWebChannel = Services.io.newURI(url);
-    const authChannel = new WebChannel("record-replay-token", urlForWebChannel);
+    authChannel = new WebChannel("record-replay-token", urlForWebChannel);
 
     authChannel.listen(handleAuthChannelMessage);
   }

--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -309,6 +309,7 @@ function isLoggedIn() {
 
 async function saveRecordingToken(token) {
   ReplayAuth.setReplayUserToken(token);
+  gShouldValidateUrl = null;
 }
 
 function isRunningTest() {
@@ -1487,5 +1488,5 @@ var EXPORTED_SYMBOLS = [
   "RecordingState",
   "isLoggedIn",
   "saveRecordingToken",
-  "isRunningTest"
+  "isRunningTest",
 ];

--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -58,13 +58,6 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   E10SUtils: "resource://gre/modules/E10SUtils.jsm",
 });
 
-XPCOMUtils.defineLazyServiceGetter(
-  this,
-  "gExternalProtocolService",
-  "@mozilla.org/uriloader/external-helper-app-service;1",
-  Ci.nsIExternalProtocolService
-);
-
 let updateStatusCallback = null;
 let connectionStatus = "cloudConnecting.label";
 let gShouldValidateUrl = null;
@@ -316,7 +309,6 @@ function isLoggedIn() {
 
 async function saveRecordingToken(token) {
   ReplayAuth.setReplayUserToken(token);
-  gShouldValidateUrl = null;
 }
 
 function isRunningTest() {
@@ -1483,45 +1475,6 @@ distributor.addObserver({
   },
 });
 
-function openSigninPage() {
-  const key = btoa(Array.from({length: 32}, () => String.fromCodePoint(Math.floor(Math.random() * 256))).join(""))
-  const url = Services.io.newURI(`http://localhost:8080/api/browser/auth?key=${key}`);
-
-  gExternalProtocolService
-    .getProtocolHandlerInfo("https")
-    .launchWithURI(url);
-
-  Promise.race([
-    new Promise((_resolve, reject) => setTimeout(reject, 2 * 60 * 1000)),
-    new Promise(async (resolve, reject) => {
-      let retries = 0;
-      while (retries < 20) {
-        const resp = await queryAPIServer(`
-          mutation CloseAuthRequest($key: String!) {
-            closeAuthRequest(input: {key: $key}) {
-              success
-              token
-            }
-          }
-        `, {
-          key
-        });
-
-        if (resp.errors) {
-          retries++;
-          await new Promise(resolve => setTimeout(resolve, 1000));
-        } else {
-          ReplayAuth.setReplayUserToken(resp.data.closeAuthRequest.token);
-          resolve();
-          break;
-        }
-      }
-
-      reject(`Failed to authenticate`);
-    })
-  ]).catch(console.error);
-}
-
 // eslint-disable-next-line no-unused-vars
 var EXPORTED_SYMBOLS = [
   "setConnectionStatusChangeCallback",
@@ -1534,6 +1487,5 @@ var EXPORTED_SYMBOLS = [
   "RecordingState",
   "isLoggedIn",
   "saveRecordingToken",
-  "isRunningTest",
-  "openSigninPage"
+  "isRunningTest"
 ];

--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -58,6 +58,13 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   E10SUtils: "resource://gre/modules/E10SUtils.jsm",
 });
 
+XPCOMUtils.defineLazyServiceGetter(
+  this,
+  "gExternalProtocolService",
+  "@mozilla.org/uriloader/external-helper-app-service;1",
+  Ci.nsIExternalProtocolService
+);
+
 let updateStatusCallback = null;
 let connectionStatus = "cloudConnecting.label";
 let gShouldValidateUrl = null;
@@ -1476,6 +1483,45 @@ distributor.addObserver({
   },
 });
 
+function openSigninPage() {
+  const key = btoa(Array.from({length: 32}, () => String.fromCodePoint(Math.floor(Math.random() * 256))).join(""))
+  const url = Services.io.newURI(`http://localhost:8080/api/browser/auth?key=${key}`);
+
+  gExternalProtocolService
+    .getProtocolHandlerInfo("https")
+    .launchWithURI(url);
+
+  Promise.race([
+    new Promise((_resolve, reject) => setTimeout(reject, 2 * 60 * 1000)),
+    new Promise(async (resolve, reject) => {
+      let retries = 0;
+      while (retries < 20) {
+        const resp = await queryAPIServer(`
+          mutation CloseAuthRequest($key: String!) {
+            closeAuthRequest(input: {key: $key}) {
+              success
+              token
+            }
+          }
+        `, {
+          key
+        });
+
+        if (resp.errors) {
+          retries++;
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        } else {
+          ReplayAuth.setReplayUserToken(resp.data.closeAuthRequest.token);
+          resolve();
+          break;
+        }
+      }
+
+      reject(`Failed to authenticate`);
+    })
+  ]).catch(console.error);
+}
+
 // eslint-disable-next-line no-unused-vars
 var EXPORTED_SYMBOLS = [
   "setConnectionStatusChangeCallback",
@@ -1489,4 +1535,5 @@ var EXPORTED_SYMBOLS = [
   "isLoggedIn",
   "saveRecordingToken",
   "isRunningTest",
+  "openSigninPage"
 ];

--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -309,7 +309,6 @@ function isLoggedIn() {
 
 async function saveRecordingToken(token) {
   ReplayAuth.setReplayUserToken(token);
-  gShouldValidateUrl = null;
 }
 
 function isRunningTest() {
@@ -335,6 +334,7 @@ if (ReplayAuth.hasOriginalApiKey()) {
 
     let token = ReplayAuth.getReplayUserToken();
     if (!token) {
+      gShouldValidateUrl = null;
       return;
     }
 

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -36,19 +36,19 @@ const { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );
 const {
-  openSigninPage,
   getConnectionStatus,
   setConnectionStatusChangeCallback,
   toggleRecording,
   getRecordingState,
   RecordingState,
   isLoggedIn,
-  saveRecordingToken,
   isRunningTest,
 } = ChromeUtils.import(
   "resource://devtools/server/actors/replay/connection.js"
 );
-
+const { openSigninPage } = ChromeUtils.import(
+  "resource://devtools/server/actors/replay/auth.js"
+);
 const { pingTelemetry } = ChromeUtils.import(
   "resource://devtools/server/actors/replay/telemetry.js"
 );
@@ -426,6 +426,7 @@ DevToolsStartup.prototype = {
           this.hookDeveloperToggle();
         }
 
+        initAuth();
         this.hookRecordingButton();
         this.hookProfilerRecordingButton();
       }
@@ -657,7 +658,6 @@ DevToolsStartup.prototype = {
       return;
     }
     this.recordingButtonCreated = true;
-    this.initializeRecordingWebChannel();
 
     createRecordingButton();
   },
@@ -739,25 +739,6 @@ DevToolsStartup.prototype = {
     }
   },
 
-  initializeRecordingWebChannel() {
-    // const pageUrl = Services.prefs.getStringPref(
-    //   "devtools.recordreplay.recordingsUrl"
-    // );
-    // const localUrl = "http://localhost:8080/view";
-
-    // registerWebChannel(pageUrl);
-    // registerWebChannel(localUrl);
-
-    // function registerWebChannel(url) {
-    //   const urlForWebChannel = Services.io.newURI(url);
-    //   const channel = new WebChannel("record-replay-token", urlForWebChannel);
-
-    //   channel.listen((id, message) => {
-    //     const { token } = message;
-    //     saveRecordingToken(token);
-    //   });
-    // }
-  },
   /*
    * We listen to the "Web Developer" system menu, which is under "Tools" main item.
    * This menu item is hardcoded empty in Firefox UI. We listen for its opening to

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1488,25 +1488,6 @@ function createRecordingButton() {
   });
 }
 
-function refreshRecordingButton(doc) {
-  const node = doc.getElementById("record-button");
-  if (node) {
-    node.refreshStatus();
-  }
-  const signinNode = doc.getElementById("replay-signin-button");
-  if (signinNode) {
-    signinNode.refreshStatus();
-  }
-}
-
-function refreshAllRecordingButtons() {
-  try {
-    for (const w of Services.wm.getEnumerator("navigator:browser")) {
-      refreshRecordingButton(w.document);
-    }
-  } catch (e) {}
-}
-
 function pickSigninPage(gBrowser) {
   const externalAuthFlow = Services.prefs.getBoolPref("devtools.recordreplay.ext-auth", false);
 
@@ -1528,6 +1509,25 @@ function pickSigninPage(gBrowser) {
   } else {
     gBrowser.selectedTab = gBrowser.addTab(url, options);
   }
+}
+
+function refreshRecordingButton(doc) {
+  const node = doc.getElementById("record-button");
+  if (node) {
+    node.refreshStatus();
+  }
+  const signinNode = doc.getElementById("replay-signin-button");
+  if (signinNode) {
+    signinNode.refreshStatus();
+  }
+}
+
+function refreshAllRecordingButtons() {
+  try {
+    for (const w of Services.wm.getEnumerator("navigator:browser")) {
+      refreshRecordingButton(w.document);
+    }
+  } catch (e) {}
 }
 
 // When state changes which affects the recording buttons, we try to update the

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -36,6 +36,7 @@ const { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );
 const {
+  openSigninPage,
   getConnectionStatus,
   setConnectionStatusChangeCallback,
   toggleRecording,
@@ -739,23 +740,23 @@ DevToolsStartup.prototype = {
   },
 
   initializeRecordingWebChannel() {
-    const pageUrl = Services.prefs.getStringPref(
-      "devtools.recordreplay.recordingsUrl"
-    );
-    const localUrl = "http://localhost:8080/view";
+    // const pageUrl = Services.prefs.getStringPref(
+    //   "devtools.recordreplay.recordingsUrl"
+    // );
+    // const localUrl = "http://localhost:8080/view";
 
-    registerWebChannel(pageUrl);
-    registerWebChannel(localUrl);
+    // registerWebChannel(pageUrl);
+    // registerWebChannel(localUrl);
 
-    function registerWebChannel(url) {
-      const urlForWebChannel = Services.io.newURI(url);
-      const channel = new WebChannel("record-replay-token", urlForWebChannel);
+    // function registerWebChannel(url) {
+    //   const urlForWebChannel = Services.io.newURI(url);
+    //   const channel = new WebChannel("record-replay-token", urlForWebChannel);
 
-      channel.listen((id, message) => {
-        const { token } = message;
-        saveRecordingToken(token);
-      });
-    }
+    //   channel.listen((id, message) => {
+    //     const { token } = message;
+    //     saveRecordingToken(token);
+    //   });
+    // }
   },
   /*
    * We listen to the "Web Developer" system menu, which is under "Tools" main item.
@@ -1430,7 +1431,7 @@ function createRecordingButton() {
       const { selectedBrowser } = node.ownerDocument.defaultView.gBrowser;
       if (!isLoggedIn()) {
         pingTelemetry("browser", "recording-button-click-while-logged-out");
-        openSigninPage(selectedBrowser);
+        openSigninPage();
         return;
       }
 
@@ -1483,8 +1484,8 @@ function createRecordingButton() {
     id: "replay-signin-button",
     type: "button",
     tooltiptext: "replay-signin-button.tooltiptext2",
-    onClick(evt) {
-      openSigninPage(evt.target.ownerDocument.defaultView.gBrowser);
+    onClick() {
+      openSigninPage();
     },
     onCreated(node) {
       node.refreshStatus = () => {
@@ -1504,22 +1505,6 @@ function createRecordingButton() {
     dump(`CloudReplayStatus ${status}\n`);
     refreshAllRecordingButtons();
   });
-}
-
-function openSigninPage(gBrowser) {
-  const url = "https://app.replay.io/?signin=true";
-  const options = { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() };
-
-  // open a new tab to authenticate if not on a replay (or auth0 replay) host
-  const host = gBrowser.selectedBrowser.documentURI.host;
-  if (getRecordingState(gBrowser.selectedBrowser) === RecordingState.READY && (
-    /(\.|^)replay.io$/.test(host) ||
-    "webreplay.us.auth0.com" === host
-  )) {
-    gBrowser.loadURI(url, options);
-  } else {
-    gBrowser.selectedTab = gBrowser.addTab(url, options);
-  }
 }
 
 function refreshRecordingButton(doc) {

--- a/toolkit/mozapps/handling/ContentDispatchChooser.jsm
+++ b/toolkit/mozapps/handling/ContentDispatchChooser.jsm
@@ -238,6 +238,10 @@ const { toggleRecording } = ChromeUtils.import(
   "resource://devtools/server/actors/replay/connection.js"
 );
 
+const { getenv } = ChromeUtils.import(
+  "resource://devtools/server/actors/replay/env.js"
+);
+
 const { pingTelemetry } = ChromeUtils.import(
   "resource://devtools/server/actors/replay/telemetry.js"
 );
@@ -245,7 +249,7 @@ const { pingTelemetry } = ChromeUtils.import(
 // [Replay] - Mapping of replay: URL scheme values to destinations. Can either
 // be a URL or a function which invokes arbitrary browser-chrome functionality
 const replaySchemeMap = {
-  library: 'https://app.replay.io/',
+  library: getenv("RECORD_REPLAY_VIEW_HOST") || "https://app.replay.io/",
   migrate: (uri, principal, browsingContext) => {
     const win = browsingContext.topFrameElement.getTabBrowser().ownerGlobal;
     MigrationUtils.showMigrationWizard(win, [


### PR DESCRIPTION
Primarily, this adds a new auth flow that launches the user's preferred browser to complete authentication. While the user completes the auth flow, the Replay browser polls (every 3 seconds over 2 minutes) the backend to retrieve the token. Once retrieved, the Replay browser exchanges the refresh token for an auth token and passes it to the app via `WebChannel`.

It continues to support the existing auth flow (even when the feature is enabled) so the user can use app's login button from the Replay browser as before.

* Adds `devtools.recordreplay.ext-auth` (defaults to `false`) to enable the new external auth flow
* Updates `api-server` to allow valid unauthenticated requests by omitting the `Authorization` header when unset
* Consolidates auth-related logic (`openSigninPage` and `initializeRecordingWebChannel`) to `auth.js`

![image](https://user-images.githubusercontent.com/788456/147532508-82f675f3-901f-46d8-aee9-eac6535eb052.png)