### PR TITLE
Fix devtools close button to be interactive when devtools are disabled

### DIFF
--- a/devtools/client/themes/toolbox.css
+++ b/devtools/client/themes/toolbox.css
@@ -590,3 +590,8 @@
   color: #7e6c8f;
   list-style-image: url("chrome://global/skin/icons/replay-logo-light.svg");
 }
+
+#recording-overlay[hidden="false"] ~ #toolbox-toolbar-mount #toolbox-close {
+  /* Has to be larger than the z-index of reording-overlay */
+  z-index: 1000;
+}


### PR DESCRIPTION
## Issue

The close button of devtools is obscured by the overlay which makes it harder to close the devtools we just told the user they couldn't use.

Fixed #564 

## Resolution

Increase the `z-index` of the close button when the overlay is showing

https://user-images.githubusercontent.com/788456/146651663-391c9300-01c4-4c83-8647-edd9c48258d9.mp4

