### PR TITLE
Allow specifying driver revision in build/test branch action

### DIFF
--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -16,8 +16,11 @@ if (branchName.includes("webreplay-release")) {
 
 const replayRevision = getLatestReplayRevision();
 
+const driverRevision = process.env.DRIVER_REVISION;
+console.log("DriverRevision", driverRevision);
+
 sendBuildTestRequest({
-  name: `Gecko Build/Test Branch ${branchName} ${replayRevision}`,
+  name: `Gecko Build/Test Branch ${branchName} ${replayRevision}${driverRevision ? " driver " + driverRevision : ""}`,
   tasks: [
     ...platformTasks("macOS"),
     ...platformTasks("linux"),
@@ -33,6 +36,7 @@ function platformTasks(platform) {
       runtime: "gecko",
       revision: replayRevision,
       branch: branchName,
+      driverRevision,
     },
     platform
   );
@@ -43,6 +47,7 @@ function platformTasks(platform) {
       kind: "StaticLiveTests",
       runtime: "gecko",
       revision: replayRevision,
+      driverRevision,
     },
     platform,
     [buildReplayTask]

--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -1,6 +1,10 @@
 name: Build/Test Branch
 on:
   workflow_dispatch:
+    inputs:
+      driver_revision:
+        description: "Driver revision to use, if not the latest"
+        required: false
 
 jobs:
   build-test:

--- a/build.js
+++ b/build.js
@@ -3,11 +3,18 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 const gecko = __dirname;
 
-// Download the latest record/replay driver archive.
+// Download the record/replay driver archive, using the latest version unless
+//it was overridden via the environment.
 const driverArchive = `${currentPlatform()}-recordreplay.tgz`;
+let downloadArchive = driverArchive;
+if (process.env.DRIVER_REVISION) {
+  downloadArchive = `${currentPlatform()}-recordreplay-${process.env.DRIVER_REVISION}.tgz`;
+}
+spawnChecked("curl", [`https://static.replay.io/downloads/${downloadArchive}`, "-o", driverArchive], { stdio: "inherit" });
+
+// Files which should be in the archive.
 const driverFile = `${currentPlatform()}-recordreplay.${driverExtension()}`;
 const driverJSON = `${currentPlatform()}-recordreplay.json`;
-spawnChecked("curl", [`https://static.replay.io/downloads/${driverArchive}`, "-o", driverArchive], { stdio: "inherit" });
 spawnChecked("tar", ["xf", driverArchive]);
 fs.unlinkSync(driverArchive);
 


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/4011.  Allows the build script to use a specific driver when specified via the environment, and allows setting that driver when triggering a build/test action for a branch.