### PR TITLE
Expose fetch() and XHR response bodies to the driver for access.

### DIFF
--- a/dom/xhr/XMLHttpRequestMainThread.cpp
+++ b/dom/xhr/XMLHttpRequestMainThread.cpp
@@ -41,6 +41,7 @@
 #include "mozilla/StaticPrefs_dom.h"
 #include "mozilla/StaticPrefs_network.h"
 #include "mozilla/StaticPrefs_privacy.h"
+#include "mozilla/RecordReplay.h"
 #include "mozilla/dom/ProgressEvent.h"
 #include "nsIJARChannel.h"
 #include "nsIJARURI.h"
@@ -2522,7 +2523,7 @@ nsresult XMLHttpRequestMainThread::InitiateFetch(
       // 'this'. Make sure to hold a strong reference so that we don't leak the
       // wrapper.
       nsCOMPtr<nsIStreamListener> listener =
-          new net::nsStreamListenerWrapper(this);
+          recordreplay::WrapNetworkStreamListener(new net::nsStreamListenerWrapper(this));
       rv = preload->AsyncConsume(listener);
       if (NS_SUCCEEDED(rv)) {
         mFromPreload = true;
@@ -2702,7 +2703,7 @@ nsresult XMLHttpRequestMainThread::InitiateFetch(
   // Because of bug 682305, we can't let listener be the XHR object itself
   // because JS wouldn't be able to use it. So create a listener around 'this'.
   // Make sure to hold a strong reference so that we don't leak the wrapper.
-  nsCOMPtr<nsIStreamListener> listener = new net::nsStreamListenerWrapper(this);
+  nsCOMPtr<nsIStreamListener> listener = recordreplay::WrapNetworkStreamListener(new net::nsStreamListenerWrapper(this));
 
   // Check if this XHR is created from a tracking script.
   // If yes, lower the channel's priority.

--- a/mfbt/RecordReplay.h
+++ b/mfbt/RecordReplay.h
@@ -9,6 +9,7 @@
 #ifndef mozilla_RecordReplay_h
 #define mozilla_RecordReplay_h
 
+#include "mozilla/AlreadyAddRefed.h"
 #include "mozilla/Atomics.h"
 #include "mozilla/Attributes.h"
 #include "mozilla/TemplateLib.h"
@@ -21,6 +22,7 @@
 struct PLDHashTableOps;
 
 class nsIURI;
+class nsIStreamListener;
 
 namespace mozilla {
 
@@ -350,6 +352,7 @@ const char* GetBuildId();
 void OnTestCommand(const char* aString);
 void OnRepaintNeeded(const char* aWhy);
 bool IsTearingDownProcess();
+already_AddRefed<nsIStreamListener> WrapNetworkStreamListener(nsIStreamListener* listener);
 
 ///////////////////////////////////////////////////////////////////////////////
 // API inline function implementation

--- a/mfbt/RecordReplay.h
+++ b/mfbt/RecordReplay.h
@@ -352,6 +352,9 @@ const char* GetBuildId();
 void OnTestCommand(const char* aString);
 void OnRepaintNeeded(const char* aWhy);
 bool IsTearingDownProcess();
+
+// Wrap a given stream listener to emit an observer notification when the stream
+// begins and allow observation of a tee stream.
 already_AddRefed<nsIStreamListener> WrapNetworkStreamListener(nsIStreamListener* listener);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -74,6 +74,9 @@ static void (*gOnDebuggerStatement)();
 static void (*gOnEvent)(const char* aEvent, bool aBefore);
 static void (*gOnNetworkRequest)(const char* aId, const char* aKind, size_t aBookmark);
 static void (*gOnNetworkRequestEvent)(const char* aId);
+static void (*gOnSequenceStart)(const char* aId, const char* aKind);
+static void (*gOnSequenceData)(const char* aId, size_t offset, size_t length);
+static void (*gOnSequenceEnd)(const char* aId, size_t length);
 static void (*gOnConsoleMessage)(int aTimeWarpTarget);
 static void (*gOnAnnotation)(const char* aKind, const char* aContents);
 static size_t (*gNewTimeWarpTarget)();
@@ -105,6 +108,9 @@ void InitializeJS() {
   LoadSymbol("RecordReplayOnEvent", gOnEvent);
   LoadSymbol("RecordReplayOnNetworkRequest", gOnNetworkRequest);
   LoadSymbol("RecordReplayOnNetworkRequestEvent", gOnNetworkRequestEvent);
+  LoadSymbol("RecordReplayOnSequenceStart", gOnSequenceStart);
+  LoadSymbol("RecordReplayOnSequenceData", gOnSequenceData);
+  LoadSymbol("RecordReplayOnSequenceEnd", gOnSequenceEnd);
   LoadSymbol("RecordReplayOnConsoleMessage", gOnConsoleMessage);
   LoadSymbol("RecordReplayOnAnnotation", gOnAnnotation);
   LoadSymbol("RecordReplayNewBookmark", gNewTimeWarpTarget);
@@ -616,7 +622,7 @@ static bool Method_OnHttpRequest(JSContext* aCx, unsigned aArgc, Value* aVp) {
   nsAutoCString requestId;
   ConvertJSStringToCString(aCx, args.get(0).toString(), requestId);
 
-  double bookmark = args.get(1).toDouble();
+  double bookmark = args.get(1).toNumber();
   MOZ_RELEASE_ASSERT((uint64_t)bookmark == (uint32_t)bookmark, "bad request bookmark");
 
   gOnNetworkRequest(requestId.get(), "http", (size_t)bookmark);
@@ -635,6 +641,63 @@ static bool Method_OnHttpRequestEvent(JSContext* aCx, unsigned aArgc, Value* aVp
   ConvertJSStringToCString(aCx, args.get(0).toString(), requestId);
 
   gOnNetworkRequestEvent(requestId.get());
+  return true;
+}
+
+static bool Method_OnSequenceStart(JSContext* aCx, unsigned aArgc, Value* aVp) {
+  CallArgs args = CallArgsFromVp(aArgc, aVp);
+
+  if (!args.get(0).isString() || !args.get(1).isString()) {
+    JS_ReportErrorASCII(aCx, "Bad parameters");
+    return false;
+  }
+
+  nsAutoCString sequenceId;
+  ConvertJSStringToCString(aCx, args.get(0).toString(), sequenceId);
+
+  nsAutoCString sequenceKind;
+  ConvertJSStringToCString(aCx, args.get(1).toString(), sequenceKind);
+
+  gOnSequenceStart(sequenceId.get(), sequenceKind.get());
+  return true;
+}
+
+static bool Method_OnSequenceData(JSContext* aCx, unsigned aArgc, Value* aVp) {
+  CallArgs args = CallArgsFromVp(aArgc, aVp);
+
+  if (!args.get(0).isString() || !args.get(1).isNumber() || !args.get(2).isNumber()) {
+    JS_ReportErrorASCII(aCx, "Bad parameters");
+    return false;
+  }
+
+  nsAutoCString sequenceId;
+  ConvertJSStringToCString(aCx, args.get(0).toString(), sequenceId);
+
+  double offset = args.get(1).toNumber();
+  MOZ_RELEASE_ASSERT((uint64_t)offset == (size_t)offset, "bad offset");
+
+  double length = args.get(2).toNumber();
+  MOZ_RELEASE_ASSERT((uint64_t)length == (size_t)length, "bad length");
+
+  gOnSequenceData(sequenceId.get(), (size_t)offset, (size_t)length);
+  return true;
+}
+
+static bool Method_OnSequenceEnd(JSContext* aCx, unsigned aArgc, Value* aVp) {
+  CallArgs args = CallArgsFromVp(aArgc, aVp);
+
+  if (!args.get(0).isString() || !args.get(1).isNumber()) {
+    JS_ReportErrorASCII(aCx, "Bad parameters");
+    return false;
+  }
+
+  nsAutoCString sequenceId;
+  ConvertJSStringToCString(aCx, args.get(0).toString(), sequenceId);
+
+  double length = args.get(1).toNumber();
+  MOZ_RELEASE_ASSERT((uint64_t)length == (size_t)length, "bad length");
+
+  gOnSequenceEnd(sequenceId.get(), (size_t)length);
   return true;
 }
 
@@ -783,6 +846,9 @@ static const JSFunctionSpec gRecordReplayMethods[] = {
   JS_FN("onEvent", Method_OnEvent, 2, 0),
   JS_FN("onHttpRequest", Method_OnHttpRequest, 2, 0),
   JS_FN("onHttpRequestEvent", Method_OnHttpRequestEvent, 1, 0),
+  JS_FN("onSequenceStart", Method_OnSequenceStart, 2, 0),
+  JS_FN("onSequenceData", Method_OnSequenceData, 3, 0),
+  JS_FN("onSequenceEnd", Method_OnSequenceEnd, 2, 0),
   JS_FN("onConsoleMessage", Method_OnConsoleMessage, 1, 0),
   JS_FN("onAnnotation", Method_OnAnnotation, 2, 0),
   JS_FN("recordingId", Method_RecordingId, 0, 0),

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -74,9 +74,9 @@ static void (*gOnDebuggerStatement)();
 static void (*gOnEvent)(const char* aEvent, bool aBefore);
 static void (*gOnNetworkRequest)(const char* aId, const char* aKind, size_t aBookmark);
 static void (*gOnNetworkRequestEvent)(const char* aId);
-static void (*gOnSequenceStart)(const char* aId, const char* aKind);
-static void (*gOnSequenceData)(const char* aId, size_t offset, size_t length);
-static void (*gOnSequenceEnd)(const char* aId, size_t length);
+static void (*gOnNetworkStreamStart)(const char* aId, const char* aKind, const char* aParentId);
+static void (*gOnNetworkStreamData)(const char* aId, size_t aOffset, size_t aLength, size_t aBookmark);
+static void (*gOnNetworkStreamEnd)(const char* aId, size_t aLength);
 static void (*gOnConsoleMessage)(int aTimeWarpTarget);
 static void (*gOnAnnotation)(const char* aKind, const char* aContents);
 static size_t (*gNewTimeWarpTarget)();
@@ -108,9 +108,9 @@ void InitializeJS() {
   LoadSymbol("RecordReplayOnEvent", gOnEvent);
   LoadSymbol("RecordReplayOnNetworkRequest", gOnNetworkRequest);
   LoadSymbol("RecordReplayOnNetworkRequestEvent", gOnNetworkRequestEvent);
-  LoadSymbol("RecordReplayOnSequenceStart", gOnSequenceStart);
-  LoadSymbol("RecordReplayOnSequenceData", gOnSequenceData);
-  LoadSymbol("RecordReplayOnSequenceEnd", gOnSequenceEnd);
+  LoadSymbol("RecordReplayOnNetworkStreamStart", gOnNetworkStreamStart);
+  LoadSymbol("RecordReplayOnNetworkStreamData", gOnNetworkStreamData);
+  LoadSymbol("RecordReplayOnNetworkStreamEnd", gOnNetworkStreamEnd);
   LoadSymbol("RecordReplayOnConsoleMessage", gOnConsoleMessage);
   LoadSymbol("RecordReplayOnAnnotation", gOnAnnotation);
   LoadSymbol("RecordReplayNewBookmark", gNewTimeWarpTarget);
@@ -644,25 +644,28 @@ static bool Method_OnHttpRequestEvent(JSContext* aCx, unsigned aArgc, Value* aVp
   return true;
 }
 
-static bool Method_OnSequenceStart(JSContext* aCx, unsigned aArgc, Value* aVp) {
+static bool Method_OnNetworkStreamStart(JSContext* aCx, unsigned aArgc, Value* aVp) {
   CallArgs args = CallArgsFromVp(aArgc, aVp);
 
-  if (!args.get(0).isString() || !args.get(1).isString()) {
+  if (!args.get(0).isString() || !args.get(1).isString() || !args.get(2).isString()) {
     JS_ReportErrorASCII(aCx, "Bad parameters");
     return false;
   }
 
-  nsAutoCString sequenceId;
-  ConvertJSStringToCString(aCx, args.get(0).toString(), sequenceId);
+  nsAutoCString streamId;
+  ConvertJSStringToCString(aCx, args.get(0).toString(), streamId);
 
-  nsAutoCString sequenceKind;
-  ConvertJSStringToCString(aCx, args.get(1).toString(), sequenceKind);
+  nsAutoCString streamKind;
+  ConvertJSStringToCString(aCx, args.get(1).toString(), streamKind);
 
-  gOnSequenceStart(sequenceId.get(), sequenceKind.get());
+  nsAutoCString streamParentId;
+  ConvertJSStringToCString(aCx, args.get(2).toString(), streamParentId);
+
+  gOnNetworkStreamStart(streamId.get(), streamKind.get(), streamParentId.get());
   return true;
 }
 
-static bool Method_OnSequenceData(JSContext* aCx, unsigned aArgc, Value* aVp) {
+static bool Method_OnNetworkStreamData(JSContext* aCx, unsigned aArgc, Value* aVp) {
   CallArgs args = CallArgsFromVp(aArgc, aVp);
 
   if (!args.get(0).isString() || !args.get(1).isNumber() || !args.get(2).isNumber()) {
@@ -670,8 +673,8 @@ static bool Method_OnSequenceData(JSContext* aCx, unsigned aArgc, Value* aVp) {
     return false;
   }
 
-  nsAutoCString sequenceId;
-  ConvertJSStringToCString(aCx, args.get(0).toString(), sequenceId);
+  nsAutoCString streamId;
+  ConvertJSStringToCString(aCx, args.get(0).toString(), streamId);
 
   double offset = args.get(1).toNumber();
   MOZ_RELEASE_ASSERT((uint64_t)offset == (size_t)offset, "bad offset");
@@ -679,11 +682,11 @@ static bool Method_OnSequenceData(JSContext* aCx, unsigned aArgc, Value* aVp) {
   double length = args.get(2).toNumber();
   MOZ_RELEASE_ASSERT((uint64_t)length == (size_t)length, "bad length");
 
-  gOnSequenceData(sequenceId.get(), (size_t)offset, (size_t)length);
+  gOnNetworkStreamData(streamId.get(), (size_t)offset, (size_t)length, 0);
   return true;
 }
 
-static bool Method_OnSequenceEnd(JSContext* aCx, unsigned aArgc, Value* aVp) {
+static bool Method_OnNetworkStreamEnd(JSContext* aCx, unsigned aArgc, Value* aVp) {
   CallArgs args = CallArgsFromVp(aArgc, aVp);
 
   if (!args.get(0).isString() || !args.get(1).isNumber()) {
@@ -691,13 +694,13 @@ static bool Method_OnSequenceEnd(JSContext* aCx, unsigned aArgc, Value* aVp) {
     return false;
   }
 
-  nsAutoCString sequenceId;
-  ConvertJSStringToCString(aCx, args.get(0).toString(), sequenceId);
+  nsAutoCString streamId;
+  ConvertJSStringToCString(aCx, args.get(0).toString(), streamId);
 
   double length = args.get(1).toNumber();
   MOZ_RELEASE_ASSERT((uint64_t)length == (size_t)length, "bad length");
 
-  gOnSequenceEnd(sequenceId.get(), (size_t)length);
+  gOnNetworkStreamEnd(streamId.get(), (size_t)length);
   return true;
 }
 
@@ -846,9 +849,9 @@ static const JSFunctionSpec gRecordReplayMethods[] = {
   JS_FN("onEvent", Method_OnEvent, 2, 0),
   JS_FN("onHttpRequest", Method_OnHttpRequest, 2, 0),
   JS_FN("onHttpRequestEvent", Method_OnHttpRequestEvent, 1, 0),
-  JS_FN("onSequenceStart", Method_OnSequenceStart, 2, 0),
-  JS_FN("onSequenceData", Method_OnSequenceData, 3, 0),
-  JS_FN("onSequenceEnd", Method_OnSequenceEnd, 2, 0),
+  JS_FN("onNetworkStreamStart", Method_OnNetworkStreamStart, 3, 0),
+  JS_FN("onNetworkStreamData", Method_OnNetworkStreamData, 3, 0),
+  JS_FN("onNetworkStreamEnd", Method_OnNetworkStreamEnd, 2, 0),
   JS_FN("onConsoleMessage", Method_OnConsoleMessage, 1, 0),
   JS_FN("onAnnotation", Method_OnAnnotation, 2, 0),
   JS_FN("recordingId", Method_RecordingId, 0, 0),

--- a/toolkit/recordreplay/Network.cpp
+++ b/toolkit/recordreplay/Network.cpp
@@ -1,0 +1,96 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Interfaces for wrapping standard request binary response data streams.
+
+#include "ProcessRecordReplay.h"
+#include "nsIObserverService.h"
+#include "nsIRequest.h"
+#include "mozilla/Services.h"
+
+#include "nsCOMPtr.h"
+#include "nsComponentManagerUtils.h"
+#include "nsCycleCollectionParticipant.h"
+#include "nsIStreamListener.h"
+#include "nsISupportsImpl.h"
+#include "nsIOutputStream.h"
+#include "nsIPipe.h"
+#include "nsIChannel.h"
+#include "nsIInputStreamTee.h"
+#include "nsIStreamListenerTee.h"
+
+#include "mozilla/ToString.h"
+
+namespace mozilla::recordreplay {
+
+class ResponseRequestObserver final : public nsIRequestObserver {
+ private:
+  nsCOMPtr<nsIInputStream> mStream;
+  ~ResponseRequestObserver() = default;
+
+ public:
+  explicit ResponseRequestObserver(nsIInputStream* aStream): mStream(aStream) {}
+
+  NS_DECL_CYCLE_COLLECTING_ISUPPORTS
+  NS_DECL_CYCLE_COLLECTION_CLASS(ResponseRequestObserver)
+
+  // nsIRequestObserver
+  NS_DECL_NSIREQUESTOBSERVER
+};
+
+NS_IMPL_CYCLE_COLLECTION(ResponseRequestObserver, mStream)
+
+NS_INTERFACE_MAP_BEGIN_CYCLE_COLLECTION(ResponseRequestObserver)
+  NS_INTERFACE_MAP_ENTRY(nsIRequestObserver)
+NS_INTERFACE_MAP_END
+
+NS_IMPL_CYCLE_COLLECTING_ADDREF(ResponseRequestObserver)
+NS_IMPL_CYCLE_COLLECTING_RELEASE(ResponseRequestObserver)
+
+NS_IMETHODIMP
+ResponseRequestObserver::OnStartRequest(nsIRequest* request) {
+  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying());
+
+  nsCOMPtr<nsIIdentChannel> channel = do_QueryInterface(request);
+  nsCOMPtr<nsIObserverService> obsService = mozilla::services::GetObserverService();
+  if (channel && obsService) {
+    nsAutoString channelIdStr = NS_ConvertUTF8toUTF16(ToString(channel->ChannelId()).c_str());
+
+    obsService->NotifyObservers(mStream, "replay-response-start", channelIdStr.get());
+  } else {
+    mStream = nullptr;
+  }
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+ResponseRequestObserver::OnStopRequest(nsIRequest* request, nsresult status) {
+  return NS_OK;
+}
+
+already_AddRefed<nsIStreamListener> WrapNetworkStreamListener(nsIStreamListener* listener) {
+  if (!IsRecordingOrReplaying()) {
+    return nsCOMPtr(listener).forget();
+  }
+
+  nsCOMPtr<nsIOutputStream> outputStream;
+  nsCOMPtr<nsIInputStream> inputStream;
+  nsresult rv = NS_NewPipe(
+      getter_AddRefs(inputStream), getter_AddRefs(outputStream),
+      0, UINT32_MAX,
+      true, false);
+  MOZ_ALWAYS_SUCCEEDS(rv);
+
+  nsCOMPtr<nsIRequestObserver> observer = new ResponseRequestObserver(inputStream);
+
+  nsCOMPtr<nsIStreamListenerTee> tee = do_CreateInstance("@mozilla.org/network/stream-listener-tee;1");
+  rv = tee->Init(listener, outputStream, observer);
+  MOZ_ALWAYS_SUCCEEDS(rv);
+
+  return tee.forget();
+}
+
+} // namespace mozilla::recordreplay

--- a/toolkit/recordreplay/Network.cpp
+++ b/toolkit/recordreplay/Network.cpp
@@ -26,6 +26,8 @@
 
 namespace mozilla::recordreplay {
 
+// Define a custom class for listening for request start so that we can
+// be notified when the request begins.
 class ResponseRequestObserver final : public nsIRequestObserver {
  private:
   nsCOMPtr<nsIInputStream> mStream;

--- a/toolkit/recordreplay/moz.build
+++ b/toolkit/recordreplay/moz.build
@@ -9,6 +9,7 @@ SOURCES += [
     'Graphics.cpp',
     'HashTable.cpp',
     'JSControl.cpp',
+    'Network.cpp',
     'ProcessRecordReplay.cpp',
     'RecordReplayDriver.cpp',
 ]


### PR DESCRIPTION
This still uses the "sequence" concept I have in the backend PR, but since most of the actual important logic here isn't really reliant on a specific driver API, I figured this is fine to post as-is to get a head-start on review.

Refs https://github.com/RecordReplay/backend/issues/3676