### PR TITLE
Force IPC messages to be the same size when replaying, fixes backend …

### DIFF
--- a/ipc/chromium/src/base/pickle.cc
+++ b/ipc/chromium/src/base/pickle.cc
@@ -436,6 +436,14 @@ bool Pickle::ReadBytesInto(PickleIterator* iter, void* data,
   return iter->iter_.AdvanceAcrossSegments(buffers_, AlignInt(length) - length);
 }
 
+bool Pickle::IgnoreBytes(PickleIterator* iter, uint32_t length) const {
+  if (AlignInt(length) < length) {
+    return false;
+  }
+
+  return iter->iter_.AdvanceAcrossSegments(buffers_, AlignInt(length));
+}
+
 #ifdef MOZ_PICKLE_SENTINEL_CHECKING
 MOZ_NEVER_INLINE
 bool Pickle::ReadSentinel(PickleIterator* iter, uint32_t sentinel) const {
@@ -477,6 +485,11 @@ void Pickle::EndRead(PickleIterator& iter, uint32_t ipcMsgType) const {
           latencyMs);
     }
   }
+}
+
+void Pickle::Truncate(PickleIterator* iter) {
+  size_t dropped = buffers_.Truncate(iter->iter_);
+  header_->payload_size -= dropped;
 }
 
 void Pickle::BeginWrite(uint32_t length, uint32_t alignment) {

--- a/ipc/chromium/src/base/pickle.h
+++ b/ipc/chromium/src/base/pickle.h
@@ -82,6 +82,9 @@ class Pickle {
   // Returns the size of the Pickle's data.
   uint32_t size() const { return header_size_ + header_->payload_size; }
 
+  // Returns the size of the Pickle's header, which will not be iterated over.
+  uint32_t header_size() const { return header_size_; }
+
   typedef mozilla::BufferList<InfallibleAllocPolicy> BufferList;
 
   const BufferList& Buffers() const { return buffers_; }
@@ -122,6 +125,8 @@ class Pickle {
   // Use it for reading the object sizes.
   [[nodiscard]] bool ReadLength(PickleIterator* iter, int* result) const;
 
+  [[nodiscard]] bool IgnoreBytes(PickleIterator* iter, uint32_t length) const;
+
   [[nodiscard]] bool ReadSentinel(PickleIterator* iter, uint32_t sentinel) const
 #ifdef MOZ_PICKLE_SENTINEL_CHECKING
       ;
@@ -151,6 +156,10 @@ class Pickle {
   // before allocating |len| bytes of space, to ensure that reading |len| bytes
   // will succeed.
   bool HasBytesAvailable(const PickleIterator* iter, uint32_t len) const;
+
+  // Truncate the message at the current point, discarding any data after this
+  // point in the message.
+  void Truncate(PickleIterator* iter);
 
   // Methods for adding to the payload of the Pickle.  These values are
   // appended to the end of the Pickle's payload.  When reading values from a


### PR DESCRIPTION
…issue 3563

Fixes https://github.com/RecordReplay/backend/issues/3563.  The Pickle/BufferList changes were largely pulled from upstream changes made in https://bugzilla.mozilla.org/show_bug.cgi?id=1706374.