### PR TITLE
Add workflow for setting idle testing revision

### DIFF
--- a/.github/actions/set-idle-testing/action.yml
+++ b/.github/actions/set-idle-testing/action.yml
@@ -1,0 +1,6 @@
+name: "Set Idle Testing"
+description: "Set idle testing to current branch"
+
+runs:
+  using: "node12"
+  main: "./main.js"

--- a/.github/actions/set-idle-testing/main.js
+++ b/.github/actions/set-idle-testing/main.js
@@ -1,0 +1,51 @@
+
+const {
+  getLatestReplayRevision,
+  sendBuildTestRequest,
+  spawnChecked,
+  newTask,
+} = require("../utils");
+
+const branchName = getBranchName(process.env.GITHUB_REF);
+console.log("BranchName", branchName);
+
+const isReleaseBranch = branchName.includes("webreplay-release");
+
+// When we're on the release branch, the latest released browser will be used for
+// idle testing, even if it's not the most recent revision in the branch.
+const replayRevision = isReleaseBranch ? undefined : getLatestReplayRevision();
+
+const driverRevision = process.env.INPUT_DRIVER_REVISION;
+console.log("DriverRevision", driverRevision);
+
+sendBuildTestRequest({
+  name: `Gecko Set Idle Testing ${branchName} ${replayRevision || ""}${driverRevision ? " driver " + driverRevision : ""}`,
+  tasks: [
+    ...platformTasks("macOS"),
+    ...platformTasks("linux"),
+    ...platformTasks("windows"),
+  ],
+});
+
+function platformTasks(platform) {
+  const task = newTask(
+    `Set Idle Testing ${platform}`,
+    {
+      kind: "SetIdleTestRevision",
+      revision: replayRevision,
+      driverRevision,
+    },
+    platform
+  );
+
+  return [task];
+}
+
+function getBranchName(refName) {
+  // Strip everything after the last "/" from the ref to get the branch name.
+  const index = refName.lastIndexOf("/");
+  if (index == -1) {
+    return refName;
+  }
+  return refName.substring(index + 1);
+}

--- a/.github/workflows/set-idle-testing.yml
+++ b/.github/workflows/set-idle-testing.yml
@@ -1,0 +1,21 @@
+name: Set Idle Testing Branch
+on:
+  workflow_dispatch:
+    inputs:
+      driver_revision:
+        description: "Driver revision to use, if not the latest"
+        required: false
+
+jobs:
+  idle-test:
+    name: Set idle testing revision to current branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/set-idle-testing
+        env:
+          BUILD_TEST_AUTHORIZATION: ${{ secrets.BUILD_TEST_AUTHORIZATION }}
+          BUILD_TEST_HOSTNAME: ${{ secrets.BUILD_TEST_HOSTNAME }}
+          BUILD_TEST_PORT: ${{ secrets.BUILD_TEST_PORT }}
+          BUILD_TEST_INSECURE: ${{ secrets.BUILD_TEST_INSECURE }}


### PR DESCRIPTION
This adds a workflow to set the build used in idle testing, either to an unreleased build from a branch or the latest released browser.  See https://github.com/RecordReplay/backend/pull/3921