### PR TITLE
Remove undefined initAuth call

### DIFF
--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -426,7 +426,6 @@ DevToolsStartup.prototype = {
           this.hookDeveloperToggle();
         }
 
-        initAuth();
         this.hookRecordingButton();
         this.hookProfilerRecordingButton();
       }


### PR DESCRIPTION
This line was part of an earlier commit in #641 and should have been removed in the PR but was missed.