### PR TITLE
add new Target.getPossibleBreakpointsForMultipleSources command

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -626,7 +626,6 @@ const commands = {
   "Pause.getScope": Pause_getScope,
   "Pause.getTopFrame": Pause_getTopFrame,
   "Debugger.getPossibleBreakpoints": Debugger_getPossibleBreakpoints,
-  "Debugger.getPossibleBreakpointsForMultipleSources": Debugger_getPossibleBreakpointsForMultipleSources,
   "Debugger.getSourceContents": Debugger_getSourceContents,
   "CSS.getAppliedRules": CSS_getAppliedRules,
   "CSS.getComputedStyle": CSS_getComputedStyle,
@@ -653,6 +652,7 @@ const commands = {
   "Target.topFrameLocation": Target_topFrameLocation,
   "Target.getCurrentNetworkRequestEvent": Target_getCurrentNetworkRequestEvent,
   "Target.getCurrentNetworkStreamData": Target_getCurrentNetworkStreamData,
+  "Target.getPossibleBreakpointsForMultipleSources": Target_getPossibleBreakpointsForMultipleSources,
 };
 
 function OnProtocolCommand(method, params) {
@@ -953,11 +953,13 @@ function Debugger_getPossibleBreakpoints({ sourceId, begin, end }) {
   }
 }
 
-function Debugger_getPossibleBreakpointsForMultipleSources({ sourceIds }) {
+function Target_getPossibleBreakpointsForMultipleSources({ sourceIds }) {
   return sourceIds.map((sourceId => {
     return {
-      sourceId,
-      ...Debugger_getPossibleBreakpoints({sourceId})
+      possibleBreakpoints: {
+        sourceId,
+        ...Debugger_getPossibleBreakpoints({sourceId})
+      }
     }
   }));
 }

--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -930,7 +930,7 @@ function sourceToProtocolSourceId(source) {
   return String(id);
 }
 
-function Debugger_getPossibleBreakpoints({ sourceId, begin, end }) {
+function getPossibleBreakpoints({sourceId, begin, end}) {
   const source = protocolSourceIdToSource(sourceId);
 
   const lineLocations = new ArrayMap();
@@ -952,14 +952,17 @@ function Debugger_getPossibleBreakpoints({ sourceId, begin, end }) {
     });
   }
 }
+function Debugger_getPossibleBreakpoints({ sourceId, begin, end }) {
+  return getPossibleBreakpoints({source, begin, end});
+}
 
 function Target_getPossibleBreakpointsForMultipleSources({ sourceIds }) {
-  return { possibleBreakpoints:
-    sourceIds.map((sourceId => {
+  return {
+    possibleBreakpoints: sourceIds.map((sourceId => {
+      const { lineLocations } = getPossibleBreakpoints({sourceId});
       return {
-        sourceId,
-        ...Debugger_getPossibleBreakpoints({sourceId})
-      }
+        sourceId, lineLocations
+      };
     }))
   };
 }

--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -626,6 +626,7 @@ const commands = {
   "Pause.getScope": Pause_getScope,
   "Pause.getTopFrame": Pause_getTopFrame,
   "Debugger.getPossibleBreakpoints": Debugger_getPossibleBreakpoints,
+  "Debugger.getPossibleBreakpointsForMultipleSources": Debugger_getPossibleBreakpointsForMultipleSources,
   "Debugger.getSourceContents": Debugger_getSourceContents,
   "CSS.getAppliedRules": CSS_getAppliedRules,
   "CSS.getComputedStyle": CSS_getComputedStyle,
@@ -950,6 +951,15 @@ function Debugger_getPossibleBreakpoints({ sourceId, begin, end }) {
       return { line, columns };
     });
   }
+}
+
+function Debugger_getPossibleBreakpointsForMultipleSources({ sourceIds }) {
+  return sourceIds.map((sourceId => {
+    return {
+      sourceId,
+      ...Debugger_getPossibleBreakpoints({sourceId})
+    }
+  }));
 }
 
 function functionIdToScript(functionId) {

--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -954,14 +954,14 @@ function Debugger_getPossibleBreakpoints({ sourceId, begin, end }) {
 }
 
 function Target_getPossibleBreakpointsForMultipleSources({ sourceIds }) {
-  return sourceIds.map((sourceId => {
-    return {
-      possibleBreakpoints: {
+  return { possibleBreakpoints:
+    sourceIds.map((sourceId => {
+      return {
         sourceId,
         ...Debugger_getPossibleBreakpoints({sourceId})
       }
-    }
-  }));
+    }))
+  };
 }
 
 function functionIdToScript(functionId) {


### PR DESCRIPTION
Needed for https://github.com/RecordReplay/backend/pull/4179. As mentioned there:

> The current approach is a little bit naive, because it batches all getPossibleBreakpoints messages in a single getPossibleBreakpointsForMultipleSources message. I'm concerned this could lead to blocking the CPU for too long an not letting other messages be processed as quickly as before, having to transfer too much data in one request/response, or other similar problems.

> But since this is my first change that relies on gecko-dev changes, I wanted to get a naive version up first, test that it works and then iterate on it.

Reviewers:
- @kannanvijayan because we talked about trying this out as part of the warm start efforts.
- @loganfsmyth and @bhackett1024 to get their initial feedback on this naive implementation, in case I missed even more potential issues than described above.
