### PR TITLE
Build in the right directory on windows

### DIFF
--- a/build.js
+++ b/build.js
@@ -45,6 +45,8 @@ const buildOptions = {
     RUSTC_BOOTSTRAP: "qcms",
     // terminal-notifier can hang, so prevent it from running.
     MOZ_NOSPAM: "1",
+    // For windows-build.bat on windows.
+    GECKODIR: path.basename(process.cwd()),
   },
 };
 

--- a/windows-build.bat
+++ b/windows-build.bat
@@ -45,6 +45,6 @@ IF DEFINED GITDIR (
 )
 
 REM Start shell.
-%MOZILLABUILD%msys\bin\bash --login recordreplay/gecko-dev/windows-build.sh
+%MOZILLABUILD%msys\bin\bash --login recordreplay/%GECKODIR%/windows-build.sh
 
 EXIT /B

--- a/windows-build.sh
+++ b/windows-build.sh
@@ -1,5 +1,5 @@
 cd recordreplay
-cd gecko-dev
+cd $GECKODIR
 ./mach build || { "./mach build failed, exiting."; exit 1; }
 ./mach package
 MOZ_PRODUCT_VERSION=86.0 MAR_CHANNEL_ID=release MAR=rr-opt/dist/host/bin/mar ./tools/update-packaging/make_full_update.sh rr-opt/replay.complete.mar rr-opt/dist/replay || { "./mach repackage failed, exiting."; exit 1; }


### PR DESCRIPTION
This ports a change from the ESR branch which is needed for our build/test service to work right when building branches, as that is done from a different directory than the default $HOME/recordreplay/gecko-dev