### PR TITLE
Fix build test branch workflow to actually use the driver_revision input param

### DIFF
--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -23,3 +23,4 @@ jobs:
           BUILD_TEST_HOSTNAME: build-server.replay.prod
           BUILD_TEST_PORT: ${{ secrets.BUILD_TEST_PORT }}
           BUILD_TEST_INSECURE: ${{ secrets.BUILD_TEST_INSECURE }}
+          INPUT_DRIVER_REVISION: ${{ github.event.inputs.driver_revision }}


### PR DESCRIPTION
When starting the "build/test branch" workflow, I noticed that even though I was setting a driver revision parameter manually in the GH UI, it wasn't picked up by the [associated GH action](https://github.com/RecordReplay/gecko-dev/blob/6d80f9f5dadc0b4ae02ea960e4291ee02333ec38/.github/actions/build-test-branch/main.js#L19).

After applying this change I tested that the driver revision is correctly passed through and used by the build.

The workflow run [here](https://github.com/RecordReplay/build-test-dashboard/blob/master/main.md#gecko-buildtest-branch-get-breakpoints-batched-e1460e3e1371-2022-01-13t084449911z) was done before applying this change. Note how there's no "driver" revision info.

After applying this change, I ran a new workflow and you can see in the build dashboard [here](https://github.com/RecordReplay/build-test-dashboard/blob/master/main.md#gecko-buildtest-branch-get-breakpoints-batched-416d505027d0-driver-b64f182ccb55-2022-01-13t093018111z) that the driver revision info is present.