### PR TITLE
Fetch source maps on the using the content principal

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -1122,7 +1122,8 @@ async function uploadAllSourcemapAssets({
   sourceMapURL,
   sourceMapBaseURL
 }, browser) {
-  const result = await fetchText(browser.contentPrincipal, recordingId, sourceMapURL);
+  const contentPrincipal = browser.contentPrincipal;
+  const result = await fetchText(contentPrincipal, recordingId, sourceMapURL);
   if (!result) {
     return;
   }
@@ -1156,7 +1157,7 @@ async function uploadAllSourcemapAssets({
     // once that is detected by the sources.
     sourceMapURL.startsWith("data:") ? undefined : ensureMapUploading(),
     Promise.all(sources.map(async ({ offset, url }) => {
-      const result = await fetchText(browser.contentPrincipal, recordingId, url);
+      const result = await fetchText(contentPrincipal, recordingId, url);
       if (!result || mapUploadFailed) {
         return;
       }

--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -34,8 +34,6 @@ const { getenv, setenv } = ChromeUtils.import(
   "resource://devtools/server/actors/replay/env.js"
 );
 
-const { fetch: mainThreadFetch } = require("devtools/shared/DevToolsUtils.js");
-
 ChromeUtils.defineModuleGetter(
   this,
   "TabStateFlusher",
@@ -1283,17 +1281,13 @@ async function fetchText(browser, recordingId, url) {
       uri: urlObj.toString(),
       loadingPrincipal: browser.contentPrincipal,
       triggeringPrincipal: browser.contentPrincipal,
-      contentPolicyType: Ci.nsIContentPolicy.TYPE_OTHER,
+      contentPolicyType: Ci.nsIContentPolicy.TYPE_DOCUMENT,
       securityFlags: Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_SEC_CONTEXT_IS_NULL,
     });
 
     return await new Promise(resolve => {
-      console.log("fetching via channel");
       NetUtil.asyncFetch(channel, function(inputStream, resultCode) {
-        console.log(inputStream, resultCode);
         const str = NetUtil.readInputStreamToString(inputStream, inputStream.available());
-
-        console.log(str);
 
         resolve({
           url,
@@ -1301,26 +1295,6 @@ async function fetchText(browser, recordingId, url) {
         });
       });
     });
-
-    // const response = await fetch("/get?url=" + url, {
-    //   //
-    //   credentials: "include",
-    // });
-    // if (response.status < 200 || response.status >= 300) {
-    //   console.error("Error fetching recording resource", url, response);
-    //   pingTelemetry("sourcemap-upload", "fetch-bad-status", {
-    //     message: `Request got status: ${response.status}`,
-    //     status: response.status,
-    //     url: ["http:", "https:"].includes(urlObj.protocol) ? url : urlObj.protocol,
-    //     recordingId,
-    //   });
-    //   return null;
-    // }
-
-    // return {
-    //   url,
-    //   text: await response.text(),
-    // };
   } catch (e) {
     console.error("Exception fetching recording resource", url, e);
     pingTelemetry("sourcemap-upload", "fetch-exception", {


### PR DESCRIPTION
## Issue

#646 - If sourcemaps are on a basic auth server, we're not able to retrieve them even after the user authenticates to the site in the browser.

## Resolution

* Fetch the sourcemaps using `NetUtils.asyncFetch` and the browser `contentPrincipal`
* using `TYPE_DOCUMENT` is required for the HTTP Handler to generate the correct `partitionKey` in order to get the credentials from the auth cache.

## Related notes

* Callback from the auth prompt:  https://searchfox.org/mozilla-central/source/netwerk/protocol/http/nsHttpChannelAuthProvider.cpp#1495-1557
* Subsequent call to store the identity in the auth cache: https://searchfox.org/mozilla-central/source/netwerk/protocol/http/nsHttpChannelAuthProvider.cpp#384
* Block that calls `SetFirstPartyDomain` which led me to use `TYPE_DOCUMENT` https://searchfox.org/mozilla-central/source/netwerk/protocol/http/HttpBaseChannel.cpp#3802-3829
* And `SetFirstPartyDomain` (https://searchfox.org/mozilla-central/source/caps/OriginAttributes.cpp#155) which ultimately calls `MapTopLevelInfo` (https://searchfox.org/mozilla-central/source/caps/OriginAttributes.cpp#34-43) which generates the prefix required for fetching the credentials from the auth cache