### PR TITLE
Prevent creating source actors when recording/replaying

### DIFF
--- a/devtools/server/actors/utils/sources-manager.js
+++ b/devtools/server/actors/utils/sources-manager.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const { Ci } = require("chrome");
+const ChromeUtils = require("ChromeUtils");
 const DevToolsUtils = require("devtools/shared/DevToolsUtils");
 const { assert, fetch } = DevToolsUtils;
 const EventEmitter = require("devtools/shared/event-emitter");
@@ -34,6 +35,11 @@ class SourcesManager extends EventEmitter {
     super();
     this._thread = threadActor;
     this.allowSource = source => {
+      // Inspecting sources is not allowed when recording/replaying.
+      // The devtools should not be able to inspect/change JS state.
+      if (ChromeUtils.isRecordingOrReplaying()) {
+        return false;
+      }
       return !isHiddenSource(source) && allowSourceFn(source);
     };
 

--- a/dom/base/ChromeUtils.cpp
+++ b/dom/base/ChromeUtils.cpp
@@ -257,6 +257,11 @@ void ChromeUtils::AddProfilerMarker(
 }
 
 /* static */
+bool ChromeUtils::IsRecordingOrReplaying(GlobalObject& aGlobal) {
+  return recordreplay::IsRecordingOrReplaying();
+}
+
+/* static */
 void ChromeUtils::WaiveXrays(GlobalObject& aGlobal, JS::HandleValue aVal,
                              JS::MutableHandleValue aRetval, ErrorResult& aRv) {
   JS::RootedValue value(aGlobal.Context(), aVal);

--- a/dom/base/ChromeUtils.h
+++ b/dom/base/ChromeUtils.h
@@ -87,6 +87,8 @@ class ChromeUtils {
                                 const ProfilerMarkerOptionsOrDouble& aOptions,
                                 const Optional<nsACString>& text);
 
+  static bool IsRecordingOrReplaying(GlobalObject& aGlobal);
+
   static void OriginAttributesToSuffix(
       GlobalObject& aGlobal, const dom::OriginAttributesDictionary& aAttrs,
       nsCString& aSuffix);

--- a/dom/chrome-webidl/ChromeUtils.webidl
+++ b/dom/chrome-webidl/ChromeUtils.webidl
@@ -209,6 +209,9 @@ namespace ChromeUtils {
                          optional (ProfilerMarkerOptions or DOMHighResTimeStamp) options = {},
                          optional UTF8String text);
 
+  // Return the value of mozilla::recordreplay::IsRecordingOrReplaying().
+  boolean isRecordingOrReplaying();
+
   /**
    * IF YOU ADD NEW METHODS HERE, MAKE SURE THEY ARE THREAD-SAFE.
    */


### PR DESCRIPTION
Attempted fix for https://github.com/RecordReplay/backend/issues/3140

All the mismatches we see in that issue are in calls to the SourceActor extensionName getter.  We don't want to allow inspecting sources via the devtools while recording/replaying, so it seems best to prevent SourceActors from being created in recording/replaying processes, which will either fix this error or move it somewhere else.

This patch accomplishes this by filtering out all sources in the SourcesManager when recording/replaying, which is the only place I found which creates SourceActors.  This also adds a handy ChromeUtils.isRecordingOrReplaying() method we can use for other behavior changes like this in the future.