### PR TITLE
Add diagnostics for backend issue 4226

### DIFF
--- a/xpcom/threads/nsThreadPool.cpp
+++ b/xpcom/threads/nsThreadPool.cpp
@@ -247,6 +247,9 @@ nsThreadPool::Run() {
 
       event = mEvents.GetEvent(lock, &delay);
       if (!event) {
+        // Diagnostic for https://github.com/RecordReplay/backend/issues/4226
+        recordreplay::RecordReplayAssert("nsThreadPool::Run #5");
+
         TimeStamp now = TimeStamp::Now();
         uint32_t idleTimeoutDivider =
             (mIdleCount && mRegressiveMaxIdleTime) ? mIdleCount : 1;
@@ -289,6 +292,9 @@ nsThreadPool::Run() {
 
           AUTO_PROFILER_LABEL("nsThreadPool::Run::Wait", IDLE);
 
+          // Diagnostic for https://github.com/RecordReplay/backend/issues/4226
+          recordreplay::RecordReplayAssert("nsThreadPool::Run #6");
+
           TimeDuration delta = timeout - (now - idleSince);
           LOG(("THRD-P(%p) %s waiting [%f]\n", this, mName.BeginReading(),
                delta.ToMilliseconds()));
@@ -307,6 +313,9 @@ nsThreadPool::Run() {
       // Delay event processing to encourage whoever dispatched this event
       // to run.
       DelayForChaosMode(ChaosFeature::TaskRunning, 1000);
+
+      // Diagnostic for https://github.com/RecordReplay/backend/issues/4226
+      recordreplay::RecordReplayAssert("nsThreadPool::Run #7");
 
       // We'll handle the case of unstarted threads available
       // when we sample.


### PR DESCRIPTION
It's not clear what's going on from the call stack mismatch, so the next step here is to add some record/replay asserts to convert this to a regular recording mismatch which is easier to narrow things down from.