### PR TITLE
Support clobbering in manually triggered build/test actions

### DIFF
--- a/.github/actions/build-test/main.js
+++ b/.github/actions/build-test/main.js
@@ -7,6 +7,10 @@ const {
   newTask,
 } = require("../utils");
 
+const clobberInput = process.env.INPUT_CLOBBER;
+console.log("Clobber", clobberInput);
+const clobber = clobberInput == "true";
+
 const replayRevision = getLatestReplayRevision();
 const unmergedPlaywrightRevision = getLatestPlaywrightRevision();
 
@@ -39,6 +43,7 @@ function platformTasks(platform) {
       kind: "BuildRuntime",
       runtime: "gecko",
       revision: replayRevision,
+      clobber,
     },
     platform
   );
@@ -64,6 +69,7 @@ function platformTasks(platform) {
         kind: "BuildRuntime",
         runtime: "geckoPlaywright",
         revision: "",
+        clobber,
       },
       platform,
       [mergePlaywrightTask]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,11 @@
 name: Build/Test
 on:
   workflow_dispatch:
+    inputs:
+      clobber:
+        description: "Whether to build the browser from scratch"
+        type: boolean
+        required: false
   push:
     branches:
       - webreplay-release
@@ -27,3 +32,4 @@ jobs:
           BUILD_TEST_HOSTNAME: build-server.replay.prod
           BUILD_TEST_PORT: ${{ secrets.BUILD_TEST_PORT }}
           BUILD_TEST_INSECURE: ${{ secrets.BUILD_TEST_INSECURE }}
+          INPUT_CLOBBER: ${{ github.event.inputs.clobber }}


### PR DESCRIPTION
With our merges from upstream ESR we'll need to be able to clobber the build from time to time.  This lets us do this in the release and playwright branches, we can already do this in build/test branch actions.