### PR TITLE
Don't emit instrumentation opcodes when recording, add option to disa…

### DIFF
--- a/js/src/frontend/BytecodeEmitter.h
+++ b/js/src/frontend/BytecodeEmitter.h
@@ -1051,7 +1051,9 @@ struct MOZ_STACK_CLASS BytecodeEmitter {
   }
 
   [[nodiscard]] bool emitInstrumentation(InstrumentationKind kind) {
-    if (shouldEmitInstrumentation()) {
+    if (shouldEmitInstrumentation() &&
+        mozilla::recordreplay::IsReplaying() &&
+        !gDisableInstrumentationOpcodes) {
       return emitInstrumentationSlow(kind, std::function<bool(uint32_t)>());
     }
     return true;

--- a/js/src/vm/Initialization.cpp
+++ b/js/src/vm/Initialization.cpp
@@ -253,8 +253,12 @@ JS_PUBLIC_API const char* JS::detail::InitWithFailureDiagnostic(
   if (getenv("RECORD_REPLAY_FORCE_RECORD_JS_ASSERTS")) {
     gForceEmitRecordReplayAsserts = true;
   }
-  if (getenv("RECORD_REPLAY_DISABLE_INSTRUMENTATION_OPCODES")) {
-    gDisableInstrumentationOpcodes = true;
+  {
+    // Pass through events so we can use different values for this when replaying.
+    mozilla::recordreplay::AutoPassThroughThreadEvents pt;
+    if (getenv("RECORD_REPLAY_DISABLE_INSTRUMENTATION_OPCODES")) {
+      gDisableInstrumentationOpcodes = true;
+    }
   }
   if (mozilla::recordreplay::IsReplaying()) {
     mozilla::recordreplay::SetExecutionProgressCallback(SetExecutionProgressTargetCallback);

--- a/js/src/vm/Initialization.cpp
+++ b/js/src/vm/Initialization.cpp
@@ -253,6 +253,9 @@ JS_PUBLIC_API const char* JS::detail::InitWithFailureDiagnostic(
   if (getenv("RECORD_REPLAY_FORCE_RECORD_JS_ASSERTS")) {
     gForceEmitRecordReplayAsserts = true;
   }
+  if (getenv("RECORD_REPLAY_DISABLE_INSTRUMENTATION_OPCODES")) {
+    gDisableInstrumentationOpcodes = true;
+  }
   if (mozilla::recordreplay::IsReplaying()) {
     mozilla::recordreplay::SetExecutionProgressCallback(SetExecutionProgressTargetCallback);
   }

--- a/js/src/vm/Runtime.cpp
+++ b/js/src/vm/Runtime.cpp
@@ -914,6 +914,7 @@ void JSRuntime::ensureRealmIsRecordingAllocations(
 
 bool js::gForceEmitExecutionProgress;
 bool js::gForceEmitRecordReplayAsserts;
+bool js::gDisableInstrumentationOpcodes;
 
 uint64_t* js::ExecutionProgressCounter() {
   static uint64_t dummyCounter;

--- a/js/src/vm/Runtime.h
+++ b/js/src/vm/Runtime.h
@@ -1192,6 +1192,9 @@ extern bool gRecordDataBuffers;
 extern bool gForceEmitExecutionProgress;
 extern bool gForceEmitRecordReplayAsserts;
 
+// Set to disable emitting record/replay instrumentation opcodes.
+extern bool gDisableInstrumentationOpcodes;
+
 // Current value of the record/replay progress counter.
 extern uint64_t* ExecutionProgressCounter();
 extern void AdvanceExecutionProgressCounter();


### PR DESCRIPTION
…ble them when replaying

For https://github.com/RecordReplay/backend/issues/655.  We emit instrumentation opcodes when both recording and replaying, even though they will only be used when replaying.  The replaying version of node only emits instrumentation opcodes when replaying (they have more overhead there), and we should do the same here.  This PR makes this change, and also uses an environment variable to allow disabling instrumentation opcodes when replaying as well, for measuring their effect on performance.