### PR TITLE
Support running build/test branch action against release branch when …

### DIFF
--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -22,11 +22,23 @@ const clobberInput = process.env.INPUT_CLOBBER;
 console.log("Clobber", clobberInput);
 const clobber = clobberInput == "true";
 
+const slotInput = process.env.INPUT_SLOT;
+console.log("Slot", slotInput);
+const slot = slotInput ? +slotInput : undefined;
+
 const buildOnly = !!process.env.BUILD_ONLY;
 console.log("BuildOnly", buildOnly);
 
+let requestName = `Gecko Build/Test Branch ${branchName} ${replayRevision}`;
+if (driverRevision) {
+  requestName += ` driver ${driverRevision}`;
+}
+if (slot) {
+  requestName += ` slot ${slot}`;
+}
+
 sendBuildTestRequest({
-  name: `Gecko Build/Test Branch ${branchName} ${replayRevision}${driverRevision ? " driver " + driverRevision : ""}`,
+  name: requestName,
   tasks: [
     ...platformTasks("macOS"),
     ...platformTasks("linux"),
@@ -42,6 +54,7 @@ function platformTasks(platform) {
       runtime: "gecko",
       revision: replayRevision,
       branch: branchName,
+      branchSlot: slot,
       driverRevision,
       clobber,
     },

--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -8,15 +8,15 @@ const {
 const branchName = getBranchName(process.env.GITHUB_REF);
 console.log("BranchName", branchName);
 
-if (branchName.includes("webreplay-release")) {
-  console.error("Use build/test action for release branch");
-  process.exit(1);
-}
-
 const replayRevision = getLatestReplayRevision();
 
 const driverRevision = process.env.INPUT_DRIVER_REVISION;
 console.log("DriverRevision", driverRevision);
+
+if (branchName.includes("webreplay-release") && !driverRevision) {
+  console.error("Use build/test action for release branch");
+  process.exit(1);
+}
 
 const clobberInput = process.env.INPUT_CLOBBER;
 console.log("Clobber", clobberInput);

--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -6,8 +6,11 @@ on:
         description: "Driver revision to use, if not the latest"
         required: false
       clobber:
-        description: "Whether to build the browser from scratch"
+        description: "Build the browser from scratch"
         type: boolean
+        required: false
+      slot:
+        description: "Checked out repository slot to use"
         required: false
 
 jobs:
@@ -29,3 +32,4 @@ jobs:
           BUILD_TEST_INSECURE: ${{ secrets.BUILD_TEST_INSECURE }}
           INPUT_DRIVER_REVISION: ${{ github.event.inputs.driver_revision }}
           INPUT_CLOBBER: ${{ github.event.inputs.clobber }}
+          INPUT_SLOT: ${{ github.events.inputs.slot }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       clobber:
-        description: "Whether to build the browser from scratch"
+        description: "Build the browser from scratch"
         type: boolean
         required: false
   push:


### PR DESCRIPTION
…a driver revision is specified

I just ran into this, but it would be nice if we could use the build/test branch action to build from the release branch, when we're using an unreleased driver.