### PR TITLE
Avoid calling RecordReplayAssert from RegisterProxy

### DIFF
--- a/accessible/ipc/win/PlatformChild.cpp
+++ b/accessible/ipc/win/PlatformChild.cpp
@@ -81,6 +81,9 @@ PlatformChild::PlatformChild()
   // IA2 needs to be registered in both the main thread's STA as well as the MTA
   UniquePtr<mozilla::mscom::RegisteredProxy> ia2ProxyMTA;
   mozilla::mscom::EnsureMTA([&ia2ProxyMTA]() -> void {
+    // https://github.com/RecordReplay/backend/issues/4393
+    mozilla::recordreplay::RecordReplayAssert("PlatformChild::PlatformChild RegisterProxyCallback");
+
     ia2ProxyMTA = mozilla::mscom::RegisterProxy(L"ia2marshal.dll");
   });
   mIA2ProxyMTA = std::move(ia2ProxyMTA);

--- a/ipc/mscom/Registration.cpp
+++ b/ipc/mscom/Registration.cpp
@@ -194,30 +194,20 @@ UniquePtr<RegisteredProxy> RegisterProxy() {
 
 UniquePtr<RegisteredProxy> RegisterProxy(const wchar_t* aLeafName,
                                          RegistrationFlags aFlags) {
-  // https://github.com/RecordReplay/backend/issues/4393
-  mozilla::recordreplay::RecordReplayAssert("RegisterProxy Start");
-
   wchar_t modulePathBuf[MAX_PATH + 1] = {0};
   if (!BuildLibPath(aFlags, modulePathBuf, ArrayLength(modulePathBuf),
                     aLeafName)) {
-    // https://github.com/RecordReplay/backend/issues/4393
-    mozilla::recordreplay::RecordReplayAssert("RegisterProxy #1");
     return nullptr;
   }
 
   nsModuleHandle proxyDll(LoadLibrary(modulePathBuf));
   if (!proxyDll.get()) {
-    // https://github.com/RecordReplay/backend/issues/4393
-    mozilla::recordreplay::RecordReplayAssert("RegisterProxy #2");
     return nullptr;
   }
 
   // Instantiate an activation context so that CoGetClassObject will use any
   // COM metadata embedded in proxyDll's manifest to resolve CLSIDs.
   ActivationContextRegion actCtxRgn(proxyDll.get());
-
-  // https://github.com/RecordReplay/backend/issues/4393
-  mozilla::recordreplay::RecordReplayAssert("RegisterProxy #3");
 
   auto GetProxyDllInfoFn = reinterpret_cast<decltype(&GetProxyDllInfo)>(
       GetProcAddress(proxyDll, "GetProxyDllInfo"));


### PR DESCRIPTION
There's a build break introduced by the diagnostics added in https://github.com/RecordReplay/gecko-dev/pull/703 --- RegisterProxy doesn't include record/replay headers and the file has a scary warning at the top:

```
/* This code MUST NOT use any non-inlined internal Mozilla APIs, as it will be
   compiled into DLLs that COM may load into non-Mozilla processes! */
```

I think it's better if we don't touch this file at all, and add a recording assertion at the call site in a file where we're allowed to call record/replay functions.  This PR makes that change.