### PR TITLE
Disable code transformations related to performance.now() calls

### DIFF
--- a/dom/performance/Performance.cpp
+++ b/dom/performance/Performance.cpp
@@ -98,9 +98,6 @@ DOMHighResTimeStamp Performance::TimeStampToDOMHighResForRendering(
 }
 
 DOMHighResTimeStamp Performance::Now() {
-  // https://github.com/RecordReplay/backend/issues/4405
-  mozilla::recordreplay::AssertScriptedCaller("Performance::Now");
-
   DOMHighResTimeStamp rawTime = NowUnclamped();
 
   // XXX: Remove this would cause functions in pkcs11f.h to fail.

--- a/dom/webidl/Performance.webidl
+++ b/dom/webidl/Performance.webidl
@@ -24,6 +24,8 @@ interface Performance : EventTarget {
   // to ensure these calls occur at consistent points when recording/replaying, and
   // it also ensures that developers using performance.now() will be able to measure
   // the timing for the things they think they are measuring.
+  //
+  // See https://github.com/RecordReplay/backend/issues/4405
   //[DependsOn=DeviceState, Affects=Nothing]
   DOMHighResTimeStamp now();
 

--- a/dom/webidl/Performance.webidl
+++ b/dom/webidl/Performance.webidl
@@ -20,7 +20,11 @@ typedef sequence <PerformanceEntry> PerformanceEntryList;
 // https://w3c.github.io/hr-time/#sec-performance
 [Exposed=(Window,Worker)]
 interface Performance : EventTarget {
-  [DependsOn=DeviceState, Affects=Nothing]
+  // Disallow code transformations related to performance.now() calls. This is needed
+  // to ensure these calls occur at consistent points when recording/replaying, and
+  // it also ensures that developers using performance.now() will be able to measure
+  // the timing for the things they think they are measuring.
+  //[DependsOn=DeviceState, Affects=Nothing]
   DOMHighResTimeStamp now();
 
   [Constant]


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/4405