### PR TITLE
Ensure timer thread wrapper mutex is initialized at a consistent point

### DIFF
--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -162,7 +162,12 @@ static void ConfigureGecko() {
   // Don't create a stylo thread pool when recording or replaying.
   putenv((char*)"STYLO_THREADS=1");
 
-  // These mutexes need to be initialized at consistent points.
+  // StaticMutex objects initialize their underlying mutex the first time they
+  // are locked. If two threads are racing to do this initialization then it
+  // can happen at different points when recording vs. replaying, and we get
+  // mismatches that cause replaying failures. To work around this we
+  // initialize these mutexes explicitly here so that it happens at a
+  // consistent point in time.
   image::RecordReplayInitializeSurfaceCacheMutex();
   RecordReplayInitializeTimerThreadWrapperMutex();
 

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -45,6 +45,8 @@ namespace image {
   extern void RecordReplayInitializeSurfaceCacheMutex();
 }
 
+extern void RecordReplayInitializeTimerThreadWrapperMutex();
+
 namespace recordreplay {
 
 MOZ_NEVER_INLINE void BusyWait() {
@@ -160,8 +162,9 @@ static void ConfigureGecko() {
   // Don't create a stylo thread pool when recording or replaying.
   putenv((char*)"STYLO_THREADS=1");
 
-  // This mutex needs to be initialized on a consistent thread.
+  // These mutexes need to be initialized at consistent points.
   image::RecordReplayInitializeSurfaceCacheMutex();
+  RecordReplayInitializeTimerThreadWrapperMutex();
 
   // Order statically allocated mutex in intl code.
   RecordReplayOrderDefaultTimeZoneMutex();

--- a/xpcom/threads/nsTimerImpl.cpp
+++ b/xpcom/threads/nsTimerImpl.cpp
@@ -55,12 +55,27 @@ class TimerThreadWrapper {
                                              uint32_t aSearchBound);
   uint32_t AllowedEarlyFiringMicroseconds();
 
+  static void InitializeMutex();
+
  private:
   static mozilla::OrderedStaticMutex sMutex;
   TimerThread* mThread;
 };
 
 mozilla::OrderedStaticMutex TimerThreadWrapper::sMutex;
+
+/* static */ void TimerThreadWrapper::InitializeMutex() {
+  mozilla::OrderedStaticMutexAutoLock lock(sMutex);
+}
+
+namespace mozilla {
+
+// We need to initialize the mutex at a consistent point when recording/replaying.
+void RecordReplayInitializeTimerThreadWrapperMutex() {
+  TimerThreadWrapper::InitializeMutex();
+}
+
+} // namespace mozilla
 
 nsresult TimerThreadWrapper::Init() {
   nsresult rv;


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/4408