### PR TITLE
Avoid registering COM proxies when replaying

### DIFF
--- a/accessible/ipc/win/DocAccessibleChild.cpp
+++ b/accessible/ipc/win/DocAccessibleChild.cpp
@@ -23,11 +23,7 @@ DocAccessibleChild::DocAccessibleChild(DocAccessible* aDoc, IProtocol* aManager)
     : DocAccessibleChildBase(aDoc), mEmulatedWindowHandle(nullptr) {
   MOZ_COUNT_CTOR_INHERITED(DocAccessibleChild, DocAccessibleChildBase);
 
-  // Avoid creating PlatformChild when replaying, to avoid registering
-  // COM proxies. Changing internal COM state isn't supported when replaying,
-  // and isn't necessary as COM call behavior is replayed from the recording.
-  if (!sPlatformChild && !recordreplay::IsReplaying()) {
-    recordreplay::AutoPassThroughThreadEvents pt;
+  if (!sPlatformChild) {
     sPlatformChild = new PlatformChild();
     ClearOnShutdown(&sPlatformChild, ShutdownPhase::XPCOMShutdown);
   }

--- a/accessible/ipc/win/PlatformChild.cpp
+++ b/accessible/ipc/win/PlatformChild.cpp
@@ -20,6 +20,28 @@
 #include "AccessibleHypertext2_i.c"
 
 namespace mozilla {
+
+namespace mscom {
+
+UniquePtr<RegisteredProxy> RegisterProxyIfNotReplaying() {
+  if (recordreplay::IsReplaying()) {
+    return MakeUnique<RegisteredProxy>(reinterpret_cast<ITypeLib*>(0xDEADBEEF));
+  }
+  recordreplay::AutoPassThroughEvents pt;
+  return RegisterProxy();
+}
+
+UniquePtr<RegisteredProxy> RegisterProxyIfNotReplaying(const wchar_t* aLeafName,
+                                                       RegistrationFlags aFlags) {
+  if (recordreplay::IsReplaying()) {
+    return MakeUnique<RegisteredProxy>(reinterpret_cast<ITypeLib*>(0xDEADBEEF));
+  }
+  recordreplay::AutoPassThroughEvents pt;
+  return RegisterProxy(aLeafName, aFlags);
+}
+
+} // namespace mscom
+
 namespace a11y {
 
 /**
@@ -50,7 +72,7 @@ static const mozilla::mscom::ArrayData sPlatformChildArrayData[] = {
 // we intend to instantiate them. Therefore RegisterProxy() must be called
 // via EnsureMTA.
 PlatformChild::PlatformChild()
-    : mIA2Proxy(mozilla::mscom::RegisterProxy(L"ia2marshal.dll")),
+    : mIA2Proxy(RegisterProxyIfNotReplaying(L"ia2marshal.dll")),
       mAccTypelib(mozilla::mscom::RegisterTypelib(
           L"oleacc.dll",
           mozilla::mscom::RegistrationFlags::eUseSystemDirectory)),
@@ -71,25 +93,16 @@ PlatformChild::PlatformChild()
 
   UniquePtr<mozilla::mscom::RegisteredProxy> customProxy;
   mozilla::mscom::EnsureMTA([&customProxy]() -> void {
-    customProxy = mozilla::mscom::RegisterProxy();
+    customProxy = RegisterProxyIfNotReplaying();
   });
   mCustomProxy = std::move(customProxy);
-
-  // https://github.com/RecordReplay/backend/issues/4393
-  mozilla::recordreplay::RecordReplayAssert("PlatformChild::PlatformChild PostRunnable");
 
   // IA2 needs to be registered in both the main thread's STA as well as the MTA
   UniquePtr<mozilla::mscom::RegisteredProxy> ia2ProxyMTA;
   mozilla::mscom::EnsureMTA([&ia2ProxyMTA]() -> void {
-    // https://github.com/RecordReplay/backend/issues/4393
-    mozilla::recordreplay::RecordReplayAssert("PlatformChild::PlatformChild RegisterProxyCallback");
-
-    ia2ProxyMTA = mozilla::mscom::RegisterProxy(L"ia2marshal.dll");
+    ia2ProxyMTA = RegisterProxyIfNotReplaying(L"ia2marshal.dll");
   });
   mIA2ProxyMTA = std::move(ia2ProxyMTA);
-
-  // https://github.com/RecordReplay/backend/issues/4393
-  mozilla::recordreplay::RecordReplayAssert("PlatformChild::PlatformChild Done");
 }
 
 }  // namespace a11y

--- a/accessible/ipc/win/handler/AccessibleHandlerControl.cpp
+++ b/accessible/ipc/win/handler/AccessibleHandlerControl.cpp
@@ -108,8 +108,8 @@ AccessibleHandlerControl::Create(AccessibleHandlerControl** aOutObject) {
 AccessibleHandlerControl::AccessibleHandlerControl()
     : mIsRegistered(false),
       mCacheGen(0),
-      mIA2Proxy(mscom::RegisterProxy(L"ia2marshal.dll")),
-      mHandlerProxy(mscom::RegisterProxy()) {
+      mIA2Proxy(mscom::RegisterProxyIfNotReplaying(L"ia2marshal.dll")),
+      mHandlerProxy(mscom::RegisterProxyIfNotReplaying()) {
   MOZ_ASSERT(mIA2Proxy);
 }
 

--- a/accessible/windows/msaa/Platform.cpp
+++ b/accessible/windows/msaa/Platform.cpp
@@ -46,9 +46,9 @@ void a11y::PlatformInit() {
   ia2AccessibleText::InitTextChangeData();
 
   mscom::InterceptorLog::Init();
-  UniquePtr<RegisteredProxy> regCustomProxy(mscom::RegisterProxy());
+  UniquePtr<RegisteredProxy> regCustomProxy(mscom::RegisterProxyIfNotReplaying());
   gRegCustomProxy = regCustomProxy.release();
-  UniquePtr<RegisteredProxy> regProxy(mscom::RegisterProxy(L"ia2marshal.dll"));
+  UniquePtr<RegisteredProxy> regProxy(mscom::RegisterProxyIfNotReplaying(L"ia2marshal.dll"));
   gRegProxy = regProxy.release();
   UniquePtr<RegisteredProxy> regAccTlb(mscom::RegisterTypelib(
       L"oleacc.dll", RegistrationFlags::eUseSystemDirectory));

--- a/ipc/mscom/EnsureMTA.cpp
+++ b/ipc/mscom/EnsureMTA.cpp
@@ -235,9 +235,6 @@ void EnsureMTA::SyncDispatchToPersistentThread(nsIRunnable* aRunnable) {
     ::SetEvent(eventHandle);
   };
 
-  // https://github.com/RecordReplay/backend/issues/4393
-  mozilla::recordreplay::RecordReplayAssert("EnsureMTA::SyncDispatchToPersistentThread PostRunnable");
-
   nsresult rv = thread->Dispatch(
       NS_NewRunnableFunction("mscom::EnsureMTA::SyncDispatchToPersistentThread",
                              std::move(eventSetter)),
@@ -258,9 +255,6 @@ void EnsureMTA::SyncDispatchToPersistentThread(nsIRunnable* aRunnable) {
          WAIT_IO_COMPLETION) {
   }
   MOZ_ASSERT(waitResult == WAIT_OBJECT_0);
-
-  // https://github.com/RecordReplay/backend/issues/4393
-  mozilla::recordreplay::RecordReplayAssert("EnsureMTA::SyncDispatchToPersistentThread Done");
 }
 
 /**

--- a/ipc/mscom/Registration.h
+++ b/ipc/mscom/Registration.h
@@ -77,6 +77,17 @@ UniquePtr<RegisteredProxy> RegisterTypelib(
     const wchar_t* aLeafName,
     RegistrationFlags aFlags = RegistrationFlags::eUseBinDirectory);
 
+// We avoid registering COM proxies while replaying. Changing internal COM state
+// while replaying isn't necessary as COM call behavior is replayed from the recording,
+// and it's unclear what registering proxies even does as it depends on a method
+// GetProxyDllInfo for which little documentation is available. Note that we can't
+// check whether we are replaying within RegisterProxy, as it can be called from
+// non-Mozilla processes apparently (see scary comment in Registration.cpp).
+UniquePtr<RegisteredProxy> RegisterProxyIfNotReplaying();
+UniquePtr<RegisteredProxy> RegisterProxyIfNotReplaying(
+    const wchar_t* aLeafName,
+    RegistrationFlags aFlags = RegistrationFlags::eUseBinDirectory);
+
 #if defined(MOZILLA_INTERNAL_API)
 
 /**


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/4393.  This mismatch looks like it is caused by a workaround I added in https://github.com/RecordReplay/gecko-dev/commit/1062976ee0ed0ac4c23380251c4ca86d56462331.  Gecko explicitly doesn't create PlatformChild objects when replaying, and passes through events while they are created while recording, but this creation can post events to another thread where events won't be passed through, and we get the mismatched behavior.

This PR tries to clean this up more by explicitly not registering proxies when replaying, instead of trying to avoid these calls by adjusting behavior higher up the stack.  Ideally we wouldn't have to do this at all and just replayed the system calls which RegisterProxy is doing, but this function is still a complete mystery to me.  It depends on this "GetProxyDllInfo" symbol which it tries to lookup in certain DLLs, but there isn't any documentation on what this does in gecko-dev, and trying to search for it in google didn't turn up anything either.