### PR TITLE
Fix build breaks with RegisterProxy changes

### DIFF
--- a/accessible/ipc/win/PlatformChild.cpp
+++ b/accessible/ipc/win/PlatformChild.cpp
@@ -27,7 +27,7 @@ UniquePtr<RegisteredProxy> RegisterProxyIfNotReplaying() {
   if (recordreplay::IsReplaying()) {
     return MakeUnique<RegisteredProxy>(reinterpret_cast<ITypeLib*>(0xDEADBEEF));
   }
-  recordreplay::AutoPassThroughEvents pt;
+  recordreplay::AutoPassThroughThreadEvents pt;
   return RegisterProxy();
 }
 
@@ -36,7 +36,7 @@ UniquePtr<RegisteredProxy> RegisterProxyIfNotReplaying(const wchar_t* aLeafName,
   if (recordreplay::IsReplaying()) {
     return MakeUnique<RegisteredProxy>(reinterpret_cast<ITypeLib*>(0xDEADBEEF));
   }
-  recordreplay::AutoPassThroughEvents pt;
+  recordreplay::AutoPassThroughThreadEvents pt;
   return RegisterProxy(aLeafName, aFlags);
 }
 
@@ -72,7 +72,7 @@ static const mozilla::mscom::ArrayData sPlatformChildArrayData[] = {
 // we intend to instantiate them. Therefore RegisterProxy() must be called
 // via EnsureMTA.
 PlatformChild::PlatformChild()
-    : mIA2Proxy(RegisterProxyIfNotReplaying(L"ia2marshal.dll")),
+  : mIA2Proxy(mscom::RegisterProxyIfNotReplaying(L"ia2marshal.dll")),
       mAccTypelib(mozilla::mscom::RegisterTypelib(
           L"oleacc.dll",
           mozilla::mscom::RegistrationFlags::eUseSystemDirectory)),
@@ -93,14 +93,14 @@ PlatformChild::PlatformChild()
 
   UniquePtr<mozilla::mscom::RegisteredProxy> customProxy;
   mozilla::mscom::EnsureMTA([&customProxy]() -> void {
-    customProxy = RegisterProxyIfNotReplaying();
+    customProxy = mscom::RegisterProxyIfNotReplaying();
   });
   mCustomProxy = std::move(customProxy);
 
   // IA2 needs to be registered in both the main thread's STA as well as the MTA
   UniquePtr<mozilla::mscom::RegisteredProxy> ia2ProxyMTA;
   mozilla::mscom::EnsureMTA([&ia2ProxyMTA]() -> void {
-    ia2ProxyMTA = RegisterProxyIfNotReplaying(L"ia2marshal.dll");
+    ia2ProxyMTA = mscom::RegisterProxyIfNotReplaying(L"ia2marshal.dll");
   });
   mIA2ProxyMTA = std::move(ia2ProxyMTA);
 }

--- a/accessible/ipc/win/handler/AccessibleHandlerControl.cpp
+++ b/accessible/ipc/win/handler/AccessibleHandlerControl.cpp
@@ -14,6 +14,7 @@
 
 #include "AccessibleEventId.h"
 #include "AccessibleHandler.h"
+#include "mozilla/RecordReplay.h"
 #include "mozilla/RefPtr.h"
 
 namespace mozilla {
@@ -108,8 +109,8 @@ AccessibleHandlerControl::Create(AccessibleHandlerControl** aOutObject) {
 AccessibleHandlerControl::AccessibleHandlerControl()
     : mIsRegistered(false),
       mCacheGen(0),
-      mIA2Proxy(mscom::RegisterProxyIfNotReplaying(L"ia2marshal.dll")),
-      mHandlerProxy(mscom::RegisterProxyIfNotReplaying()) {
+      mIA2Proxy(mscom::RegisterProxy(L"ia2marshal.dll")),
+      mHandlerProxy(mscom::RegisterProxy()) {
   MOZ_ASSERT(mIA2Proxy);
 }
 


### PR DESCRIPTION
https://github.com/RecordReplay/gecko-dev/pull/730 has several problems that keep it from building.  I don't know why I thought it would be OK to just merge this without testing if it compiled.