### PR TITLE
Pass through AutoProfilerTextMarker.

### DIFF
--- a/tools/profiler/public/ProfilerMarkers.h
+++ b/tools/profiler/public/ProfilerMarkers.h
@@ -205,19 +205,25 @@ class MOZ_RAII AutoProfilerTextMarker {
         mText(aText) {
     MOZ_ASSERT(mOptions.Timing().EndTime().IsNull(),
                "AutoProfilerTextMarker options shouldn't have an end time");
+
+    // The AutoProfilerTextMarker's system api usage should not affect
+    // runtime determinism of any part of a normal webpage.
+    // Allow them to pass through.
+    // See https://github.com/RecordReplay/gecko-dev/issues/733
+    mozilla::recordreplay::AutoPassThroughThreadEvents pt;
+
     if (mOptions.Timing().StartTime().IsNull()) {
       mOptions.Set(mozilla::MarkerTiming::InstantNow());
     }
   }
 
   ~AutoProfilerTextMarker() {
-    // [Replay-Disagnostic]
-    // Diagnostic for crash under nsRefreshDriver::Tick
-    // https://github.com/RecordReplay/backend/issues/4467
-    mozilla::recordreplay::RecordReplayAssert(
-      "AutoProfilerTextMarker::~AutoProfilerTextMarker(): name=%s",
-      mMarkerName
-    );
+    // The AutoProfilerTextMarker's system api usage should not
+    // affect runtime determinism of any part of a normal webpage.
+    // Allow them to pass through.
+    // See https://github.com/RecordReplay/gecko-dev/issues/733
+    mozilla::recordreplay::AutoPassThroughThreadEvents pt;
+
     AUTO_PROFILER_LABEL("TextMarker", PROFILER);
     mOptions.TimingRef().SetIntervalEnd();
     AUTO_PROFILER_STATS(AUTO_PROFILER_MARKER_TEXT);


### PR DESCRIPTION
This is an RAII class used mostly for when the profiler is running in the recorded browser.  It's unexpected and should not interfere with recorded page behaviour.