### PR TITLE
Fix emitting page console events dropped by an exception in the handler

### DIFF
--- a/juggler/NetworkObserver.js
+++ b/juggler/NetworkObserver.js
@@ -886,13 +886,14 @@ function readRequestPostData(httpChannel) {
   let iStream = httpChannel.uploadStream;
   if (!iStream)
     return undefined;
-  const isSeekableStream = iStream instanceof Ci.nsISeekableStream;
 
   // For some reason, we cannot rewind back big streams,
   // so instead we should clone them.
   const isCloneable = iStream instanceof Ci.nsICloneableInputStream;
   if (isCloneable)
     iStream = iStream.clone();
+
+  const isSeekableStream = iStream instanceof Ci.nsISeekableStream;
 
   let prevOffset;
   if (isSeekableStream) {

--- a/juggler/protocol/PageHandler.js
+++ b/juggler/protocol/PageHandler.js
@@ -122,7 +122,7 @@ class PageHandler {
         pageWorkerDestroyed: this._onWorkerDestroyed.bind(this),
         runtimeConsole: params => {
           const consoleMessageHash = hashConsoleMessage(params);
-          for (const worker of this._workers) {
+          for (const [,worker] of this._workers) {
             if (worker._workerConsoleMessages.has(consoleMessageHash)) {
               worker._workerConsoleMessages.delete(consoleMessageHash);
               return;


### PR DESCRIPTION
## Issue

* An error was being thrown accessing `iStream.tell()`
* Console event were not emitted via `page.on("console", ...)`

## Analysis

* When the error was thrown, `iStream` was reassigned by `iStream.clone()`. The clone (i guess) doesn't implement `nsIseekableStream` so the prior check is no longer valid.
* The console event handler was iterating over `this._workers` which is a `Map` so the iterator was returning an array in the format `[key, value]` but the code was just expecting the `value`

## Resolution

* Move the `instanceof` check after the assignment
* Deconstruct the `value` in the `this_workers` loop