### PR TITLE
Set static dimensions to improve rendering of native window controls

### DIFF
--- a/browser/base/content/browser.css
+++ b/browser/base/content/browser.css
@@ -94,6 +94,15 @@ body {
   }
 }
 
+/* [Replay] - This seems to fix the theme overlapping the native window
+   controls but likely will require adjustment */
+@media (-moz-os-version: windows-win8),
+       (-moz-os-version: windows-win10) {
+  .titlebar-buttonbox {
+    height: 29px;
+  }
+}
+
 %ifdef MENUBAR_CAN_AUTOHIDE
 #toolbar-menubar[autohide="true"] {
   overflow: hidden;


### PR DESCRIPTION
This is kinda hacky but it seems to do the trick. The nodes within the `.titlebar-buttonbox` don't have a natural height (or the natural height retrieved from `appearance: none` by FF is falling back to the old style windows controls).