### PR TITLE
Disable hardware SHA support

### DIFF
--- a/security/nss/lib/freebl/sha512.c
+++ b/security/nss/lib/freebl/sha512.c
@@ -207,7 +207,7 @@ SHA256_Begin(SHA256Context *ctx)
 
 #if defined(USE_HW_SHA2) && defined(IS_LITTLE_ENDIAN)
     /* arm's implementation is tested on little endian only */
-    use_hw_sha2 = arm_sha2_support() || (sha_support() && ssse3_support() && sse4_1_support());
+    use_hw_sha2 = PR_FALSE; // arm_sha2_support() || (sha_support() && ssse3_support() && sse4_1_support());
 #endif
 
     if (use_hw_sha2) {
@@ -703,7 +703,7 @@ SHA224_Begin(SHA224Context *ctx)
 
 #if defined(USE_HW_SHA2) && defined(IS_LITTLE_ENDIAN)
     /* arm's implementation is tested on little endian only */
-    use_hw_sha2 = arm_sha2_support() || (sha_support() && ssse3_support() && sse4_1_support());
+    use_hw_sha2 = PR_FALSE; // arm_sha2_support() || (sha_support() && ssse3_support() && sse4_1_support());
 #else
     use_hw_sha2 = PR_FALSE;
 #endif


### PR DESCRIPTION
Experimental PR for https://github.com/RecordReplay/backend/issues/4597 --- I've had crashes while replaying from a snapshot in a recording made on other hardware, due to an illegal instruction when executing special CPU instructions for SHA 256 operations.  It seems possible this is related to restoring the snapshot on different hardware.