### PR TITLE
Proof of concept for writing sourcemaps to disk

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -221,7 +221,7 @@ function setSourceMap({
     return;
   }
   const recordingId = RecordReplayControl.recordingId();
-  if (!recordingId || !url) {
+  if (!url) {
     return;
   }
 
@@ -1337,6 +1337,31 @@ if (isRecordingOrReplaying) {
       notifyRequestEvent(channelId, "response-raw-headers", {
         responseRawHeaders,
       });
+    },
+  });
+
+  Services.cpmm.addMessageListener("RecordReplaySourcemapContents", {
+    receiveMessage({ data }) {
+      RecordReplayControl.writeSourcemap(
+        data.id || "",
+        data.contents || "",
+        data.sourceMapURL || "",
+        data.sourceMapBaseURL || "",
+        data.targetContentHash || "",
+        data.targetURLHash || "",
+        data.targetMapURLHash || ""
+      );
+    },
+  });
+
+  Services.cpmm.addMessageListener("RecordReplayOriginalSourceContents", {
+    receiveMessage({ data }) {
+      RecordReplayControl.writeOriginalSource(
+        data.parentId,
+        data.url,
+        data.contents,
+        data.parentOffset
+      );
     },
   });
 


### PR DESCRIPTION
Status:
- `module.js` fetches sourcemaps and original sources and sends them to `connection.js`
- `connection.js` passes them on to `JSControl.cpp`
- `JSControl.cpp` sends them to the driver
  - we could also write them directly from `connection.js` using `OS.File.writeAtomic()` but I'd like to have all the code for writing a recording to disk in one place
