### PR TITLE
Don't run tests in parallel when multiple test runs were specified

### DIFF
--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -78,6 +78,7 @@ function platformTasks(platform) {
           runtime: "gecko",
           revision: replayRevision,
           driverRevision,
+          noParallelTesting: testRuns > 1 ? true : undefined,
         },
         platform,
         [buildReplayTask]


### PR DESCRIPTION
When we trigger multiple test runs at once, the workload should match what we do during idle testing.