### PR TITLE
Add more diagnostics for CFGetTypeID mismatch

### DIFF
--- a/gfx/2d/ScaledFontMac.cpp
+++ b/gfx/2d/ScaledFontMac.cpp
@@ -401,7 +401,8 @@ static void CollectVariationsFromDictionary(const void* aKey,
   // [Replay-Diagnostic]
   // Diagnostic for missing call to CFGetTypeId
   // https://github.com/RecordReplay/backend/issues/4555
-  recordreplay::RecordReplayAssert("CollectVariationsFromDictionary()");
+  recordreplay::RecordReplayAssert("CollectVariationsFromDictionary() key=%p value=%p",
+                                   aKey, aValue);
   if (CFGetTypeID(keyPtr) == CFNumberGetTypeID() &&
       CFGetTypeID(valuePtr) == CFNumberGetTypeID()) {
     uint64_t t;
@@ -427,8 +428,8 @@ static bool GetVariationsForCTFont(CTFontRef aCTFont,
     // Diagnostic for missing call to CFGetTypeId
     // https://github.com/RecordReplay/backend/issues/4555
     recordreplay::RecordReplayAssert(
-      "GetVariationsForCTFont(): count=%d",
-      count
+      "GetVariationsForCTFont(): dict=%p count=%d",
+      dict, count
     );
     aOutVariations->reserve(count);
     CFDictionaryApplyFunction(dict, CollectVariationsFromDictionary,

--- a/gfx/2d/ScaledFontMac.cpp
+++ b/gfx/2d/ScaledFontMac.cpp
@@ -429,7 +429,7 @@ static bool GetVariationsForCTFont(CTFontRef aCTFont,
     // https://github.com/RecordReplay/backend/issues/4555
     recordreplay::RecordReplayAssert(
       "GetVariationsForCTFont(): dict=%p count=%d",
-      dict, count
+      (CFDictionaryRef)dict, count
     );
     aOutVariations->reserve(count);
     CFDictionaryApplyFunction(dict, CollectVariationsFromDictionary,


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/4555, I ran into this while testing on long recordings.  It would be good to see if the CF object pointers are consistent when recording vs. replaying.