### PR TITLE
Remove uses of recording ID callback

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -217,13 +217,13 @@ function setSourceMap({
   objectText,
   objectMapURL: url
 }) {
-  if (!Services.prefs.getBoolPref("devtools.recordreplay.uploadSourceMaps")) {
+  if (!Services.prefs.getBoolPref("devtools.recordreplay.uploadSourceMaps") ||
+      !RecordReplayControl.isUploadingRecording() ||
+      !url) {
     return;
   }
+
   const recordingId = RecordReplayControl.recordingId();
-  if (!recordingId || !url) {
-    return;
-  }
 
   let sourceBaseURL;
   if (typeof objectURL === "string" && isValidBaseURL(objectURL)) {

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -679,21 +679,22 @@ static bool Method_MakeBookmark(JSContext* aCx, unsigned aArgc, Value* aVp) {
   return true;
 }
 
-static bool Method_RecordingId(JSContext* aCx, unsigned aArgc,
-                                     Value* aVp) {
+static bool Method_RecordingId(JSContext* aCx, unsigned aArgc, Value* aVp) {
   CallArgs args = CallArgsFromVp(aArgc, aVp);
 
-  if (IsUploadingRecording()) {
-    const char* recordingId = GetRecordingId();
-    JSString* str = JS_NewStringCopyZ(aCx, recordingId);
-    if (!str) {
-      return false;
-    }
-
-    args.rval().setString(str);
-  } else {
-    args.rval().setNull();
+  const char* recordingId = GetRecordingId();
+  JSString* str = JS_NewStringCopyZ(aCx, recordingId);
+  if (!str) {
+    return false;
   }
+
+  args.rval().setString(str);
+  return true;
+}
+
+static bool Method_IsUploadingRecording(JSContext* aCx, unsigned aArgc, Value* aVp) {
+  CallArgs args = CallArgsFromVp(aArgc, aVp);
+  args.rval().setBoolean(IsUploadingRecording());
   return true;
 }
 
@@ -819,6 +820,7 @@ static const JSFunctionSpec gRecordReplayMethods[] = {
   JS_FN("onConsoleMessage", Method_OnConsoleMessage, 1, 0),
   JS_FN("onAnnotation", Method_OnAnnotation, 2, 0),
   JS_FN("recordingId", Method_RecordingId, 0, 0),
+  JS_FN("isUploadingRecording", Method_IsUploadingRecording, 0, 0),
   JS_FN("addMetadata", Method_AddMetadata, 1, 0),
   JS_FN("recordingOperations", Method_RecordingOperations, 0, 0),
   JS_FN("makeBookmark", Method_MakeBookmark, 0, 0),

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -683,8 +683,8 @@ static bool Method_RecordingId(JSContext* aCx, unsigned aArgc,
                                      Value* aVp) {
   CallArgs args = CallArgsFromVp(aArgc, aVp);
 
-  const char* recordingId = GetRecordingId();
-  if (recordingId) {
+  if (IsUploadingRecording()) {
+    const char* recordingId = GetRecordingId();
     JSString* str = JS_NewStringCopyZ(aCx, recordingId);
     if (!str) {
       return false;

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -320,6 +320,9 @@ static void MaybeStartProfiling() {
 // recording will not be usable.
 static bool gPretendNotRecording = false;
 
+// Whether the recorder will be directly uploading the recording, vs. writing it to disk.
+static bool gUploadingRecording = false;
+
 extern "C" {
 
 MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
@@ -436,6 +439,10 @@ MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
 #endif
 
   gAttach(*dispatchAddress, gBuildId);
+
+  if (*dispatchAddress) {
+    gUploadingRecording = true;
+  }
 
   if (TestEnv("RECORD_ALL_CONTENT")) {
     gRecordAllContent = true;
@@ -748,6 +755,10 @@ MOZ_EXPORT void RecordReplayInterface_LabelExecutableCode(const void* aCode, siz
 }
 
 }  // extern "C"
+
+bool IsUploadingRecording() {
+  return gUploadingRecording;
+}
 
 const char* GetRecordingId() {
   return gGetRecordingId();

--- a/toolkit/recordreplay/ProcessRecordReplay.h
+++ b/toolkit/recordreplay/ProcessRecordReplay.h
@@ -34,6 +34,8 @@ void InitializeGraphics();
 bool HasCheckpoint();
 void FinishRecording();
 
+const char* GetRecordingId();
+
 // If specified, all content processes are being recorded. The recording for
 // this process will be added to a file specified by an env var if it loads any
 // interesting sources.

--- a/toolkit/recordreplay/ProcessRecordReplay.h
+++ b/toolkit/recordreplay/ProcessRecordReplay.h
@@ -33,7 +33,7 @@ static inline bool TestEnv(const char* env) {
 void InitializeGraphics();
 bool HasCheckpoint();
 void FinishRecording();
-
+bool IsUploadingRecording();
 const char* GetRecordingId();
 
 // If specified, all content processes are being recorded. The recording for


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5028, the driver API changes in this issue mean that we don't need to use the recording ID callback anymore, and can call RecordReplayGetRecordingId while replaying.