### PR TITLE
Add RAII for passing through get time ops.

### DIFF
--- a/mfbt/RecordReplay.cpp
+++ b/mfbt/RecordReplay.cpp
@@ -28,6 +28,7 @@ namespace recordreplay {
 #define FOR_EACH_INTERFACE(Macro)                                              \
   Macro(InternalAreThreadEventsPassedThrough, bool, (), ())                    \
   Macro(InternalAreThreadEventsDisallowed, bool, (), ())                       \
+  Macro(InternalAreGetTimeOperationsPassedThrough, bool, (), ())               \
   Macro(InternalRecordReplayValue, size_t, (const char* aWhy, size_t aValue),  \
         (aWhy, aValue))                                                        \
   Macro(InternalHasDivergedFromRecording, bool, (), ())                        \

--- a/mfbt/RecordReplay.h
+++ b/mfbt/RecordReplay.h
@@ -118,6 +118,22 @@ struct MOZ_RAII AutoDisallowThreadEvents {
   ~AutoDisallowThreadEvents() { EndDisallowThreadEvents(); }
 };
 
+// Mark a region where thread events are passed through the record/replay
+// system. While recording, no information from system calls or other events
+// will be recorded for the thread. While replaying, system calls and other
+// events are performed normally.
+static inline void BeginPassThroughGetTimeOperations();
+static inline void EndPassThroughGetTimeOperations();
+
+// Whether events in this thread are passed through.
+static inline bool AreGetTimeOperationsPassedThrough();
+
+// RAII class to make 
+struct MOZ_RAII AutoPassThroughGetTimeOperations {
+  AutoPassThroughGetTimeOperations() { BeginPassThroughGetTimeOperations(); }
+  ~AutoPassThroughGetTimeOperations() { EndPassThroughGetTimeOperations(); }
+};
+
 // Mark a region where a note will be printed when crashing.
 static inline void PushCrashNote(const char* aNote);
 static inline void PopCrashNote();
@@ -403,6 +419,10 @@ MOZ_MAKE_RECORD_REPLAY_WRAPPER(AreThreadEventsPassedThrough, bool, false, (),
 MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(BeginDisallowThreadEvents, (), ())
 MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(EndDisallowThreadEvents, (), ())
 MOZ_MAKE_RECORD_REPLAY_WRAPPER(AreThreadEventsDisallowed, bool, false, (), ())
+MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(BeginPassThroughGetTimeOperations, (), ())
+MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(EndPassThroughGetTimeOperations, (), ())
+MOZ_MAKE_RECORD_REPLAY_WRAPPER(AreGetTimeOperationsPassedThrough, bool, false, (),
+                               ())
 MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(PushCrashNote, (const char* aNote), (aNote))
 MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(PopCrashNote, (), ())
 MOZ_MAKE_RECORD_REPLAY_WRAPPER(RecordReplayValue, size_t, aValue,

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -102,6 +102,9 @@ static bool (*gAreEventsPassedThrough)();
 static void (*gBeginDisallowEvents)();
 static void (*gEndDisallowEvents)();
 static bool (*gAreEventsDisallowed)();
+static void (*gBeginPassThroughGetTimeOperations)();
+static void (*gEndPassThroughGetTimeOperations)();
+static bool (*gAreGetTimeOperationsPassedThrough)();
 static bool (*gHasDivergedFromRecording)();
 static bool (*gIsUnhandledDivergenceAllowed)();
 static void (*gRecordReplayNewCheckpoint)();
@@ -402,6 +405,9 @@ MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
   LoadSymbol("RecordReplayBeginDisallowEvents", gBeginDisallowEvents);
   LoadSymbol("RecordReplayEndDisallowEvents", gEndDisallowEvents);
   LoadSymbol("RecordReplayAreEventsDisallowed", gAreEventsDisallowed);
+  LoadSymbol("RecordReplayBeginPassThroughGetTimeOperations", gBeginPassThroughGetTimeOperations);
+  LoadSymbol("RecordReplayEndPassThroughGetTimeOperations", gEndPassThroughGetTimeOperations);
+  LoadSymbol("RecordReplayAreGetTimeOperationsPassedThrough", gAreGetTimeOperationsPassedThrough);
   LoadSymbol("RecordReplayHasDivergedFromRecording", gHasDivergedFromRecording);
   LoadSymbol("RecordReplayIsUnhandledDivergenceAllowed", gIsUnhandledDivergenceAllowed);
   LoadSymbol("RecordReplayNewCheckpoint", gRecordReplayNewCheckpoint);
@@ -638,6 +644,18 @@ MOZ_EXPORT void RecordReplayInterface_InternalEndDisallowThreadEvents() {
 
 MOZ_EXPORT bool RecordReplayInterface_InternalAreThreadEventsDisallowed() {
   return gAreEventsDisallowed();
+}
+
+MOZ_EXPORT void RecordReplayInterface_InternalBeginPassThroughGetTimeOperations() {
+  gBeginPassThroughGetTimeOperations();
+}
+
+MOZ_EXPORT void RecordReplayInterface_InternalEndPassThroughGetTimeOperations() {
+  gEndPassThroughGetTimeOperations();
+}
+
+MOZ_EXPORT bool RecordReplayInterface_InternalAreGetTimeOperationsPassedThrough() {
+  return gAreGetTimeOperationsPassedThrough();
 }
 
 MOZ_EXPORT bool RecordReplayInterface_InternalHasDivergedFromRecording() {


### PR DESCRIPTION
The initial purpose of this for use within various
AutoProfilerTextMarker events that are triggering
mismatches on calls to clock_gettime.

The intuition is that there are places where reasonable
non-determinism during replay might spuriously cause
mismatches due to heading down irrelevant profiler codepaths,
which shouldn't matter for our purposes.