### PR TITLE
Writing sourcemaps to disk - second try

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -217,9 +217,7 @@ function setSourceMap({
   objectText,
   objectMapURL: url
 }) {
-  if (!Services.prefs.getBoolPref("devtools.recordreplay.uploadSourceMaps") ||
-      !RecordReplayControl.isUploadingRecording() ||
-      !url) {
+  if (!Services.prefs.getBoolPref("devtools.recordreplay.uploadSourceMaps") || !url) {
     return;
   }
 
@@ -252,6 +250,7 @@ function setSourceMap({
 
   Services.cpmm.sendAsyncMessage("RecordReplayGeneratedSourceWithSourceMap", {
     recordingId,
+    isUploadingRecording: RecordReplayControl.isUploadingRecording(),
     sourceMapURL,
     sourceMapBaseURL,
 


### PR DESCRIPTION
In https://github.com/RecordReplay/gecko-dev/pull/760#discussion_r833494828 @loganfsmyth pointed out two issues with my first attempt at writing sourcemaps to disk:
- the sourcemap will be included in the recording file itself
- if recording stopped while sourcemaps are still being fetched, they can't be saved

The second issue seems like a blocker since we need this feature for recording tests with playwright and I'd expect many tests to not run long enough for the sourcemaps to be fetched reliably.
With this PR, the sourcemaps and original sources are written to disk directly in `connection.js`. The metadata is not added to the `recordings.log` file because all content processes will try to save their sourcemaps in parallel and I'm not sure that appending to a file works atomically. So the metadata for each sourcemap (and original source) is written to a separate file.
