### PR TITLE
Diagnostic for recordings not being created

### DIFF
--- a/ipc/glue/ProtocolUtils.cpp
+++ b/ipc/glue/ProtocolUtils.cpp
@@ -520,9 +520,9 @@ bool IProtocol::ChannelSend(IPC::Message* aMsg) {
 
   // We don't have a way to send IPC messages at non-deterministic points.
   // For now, silently discard the messages.
-  if (recordreplay::AreThreadEventsDisallowed()) {
-    return true;
-  }
+  //if (recordreplay::AreThreadEventsDisallowed()) {
+  //  return true;
+  //}
 
   if (CanSend()) {
     // NOTE: This send call failing can only occur during toplevel channel


### PR DESCRIPTION
We're having problems with empty recordings being created during our static live tests (and playwright tests too, apparently).  This may be related to https://github.com/RecordReplay/backend/issues/4307.  This is an attempted fix to see if suppressing IPC messages when events are disallowed is causing problems.