### PR TITLE
Revert patch to fix leaking references

### DIFF
--- a/dom/base/nsWrapperCache.cpp
+++ b/dom/base/nsWrapperCache.cpp
@@ -40,6 +40,11 @@ void nsWrapperCache::SetWrapperJSObject(JSObject* aWrapper) {
   if (aWrapper && !JS::ObjectIsTenured(aWrapper)) {
     CycleCollectedJSRuntime::Get()->NurseryWrapperAdded(this);
   }
+
+  // Never collect the wrapper object while recording or replaying, to avoid
+  // non-deterministic behaviors if the cache is emptied and then refilled at
+  // a different point when replaying.
+  recordreplay::HoldJSObject(aWrapper);
 }
 
 void nsWrapperCache::ReleaseWrapper(void* aScriptObjectHolder) {

--- a/dom/bindings/BindingUtils.h
+++ b/dom/bindings/BindingUtils.h
@@ -22,6 +22,7 @@
 #include "mozilla/Array.h"
 #include "mozilla/Assertions.h"
 #include "mozilla/DeferredFinalize.h"
+#include "mozilla/RecordReplay.h"
 #include "mozilla/UniquePtr.h"
 #include "mozilla/dom/BindingCallContext.h"
 #include "mozilla/dom/BindingDeclarations.h"
@@ -2675,6 +2676,11 @@ class MOZ_STACK_CLASS BindingJSObjectCreator {
   void InitializationSucceeded() {
     T* pointer;
     mNative.forget(&pointer);
+
+    // Never collect binding objects while recording or replaying, to avoid
+    // non-deterministically releasing references during finalization.
+    recordreplay::HoldJSObject(mReflector);
+
     mReflector = nullptr;
   }
 

--- a/dom/cache/ReadStream.cpp
+++ b/dom/cache/ReadStream.cpp
@@ -575,6 +575,12 @@ void ReadStream::Serialize(
 ReadStream::ReadStream(SafeRefPtr<ReadStream::Inner> aInner)
     : mInner(std::move(aInner)) {
   MOZ_DIAGNOSTIC_ASSERT(mInner);
+
+  // Leak this class when recording/replaying, to avoid problems with the
+  // destructor being called at non-deterministic points.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    AddRef();
+  }
 }
 
 ReadStream::~ReadStream() {

--- a/dom/file/ipc/RemoteLazyInputStream.cpp
+++ b/dom/file/ipc/RemoteLazyInputStream.cpp
@@ -150,6 +150,11 @@ RemoteLazyInputStream::RemoteLazyInputStream(RemoteLazyInputStreamChild* aActor)
       }
     }
   }
+
+  // Avoid non-deterministic behavior in destructor when recording/replaying.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    AddRef();
+  }
 }
 
 RemoteLazyInputStream::~RemoteLazyInputStream() { Close(); }

--- a/dom/file/ipc/RemoteLazyInputStreamChild.cpp
+++ b/dom/file/ipc/RemoteLazyInputStreamChild.cpp
@@ -255,7 +255,7 @@ void RemoteLazyInputStreamChild::ForgetStream(RemoteLazyInputStream* aStream) {
   RefPtr<RemoteLazyInputStreamChild> kungFuDeathGrip = this;
 
   {
-    MutexAutoLockMaybeEventsDisallowed lock(mMutex);
+    MutexAutoLock lock(mMutex);
     mStreams.RemoveElement(aStream);
 
     if (!mStreams.IsEmpty() || mState != eActive) {

--- a/dom/workers/WorkerRef.cpp
+++ b/dom/workers/WorkerRef.cpp
@@ -201,6 +201,15 @@ ThreadSafeWorkerRef::ThreadSafeWorkerRef(StrongWorkerRef* aRef) : mRef(aRef) {
 ThreadSafeWorkerRef::~ThreadSafeWorkerRef() {
   // Let's release the StrongWorkerRef on the correct thread.
   if (!mRef->mWorkerPrivate->IsOnWorkerThread()) {
+    // When recording/replaying we leak the reference because this class can
+    // be destroyed in event runnable destructors that run at non-deterministic
+    // points when replaying, and we don't yet support posting events in such
+    // situations.
+    if (recordreplay::IsRecordingOrReplaying()) {
+      mRef.forget();
+      return;
+    }
+
     WorkerPrivate* workerPrivate = mRef->mWorkerPrivate;
     RefPtr<ReleaseRefControlRunnable> r =
         new ReleaseRefControlRunnable(workerPrivate, mRef.forget());

--- a/dom/workers/WorkerRunnable.cpp
+++ b/dom/workers/WorkerRunnable.cpp
@@ -52,6 +52,13 @@ WorkerRunnable::WorkerRunnable(WorkerPrivate* aWorkerPrivate,
       mCanceled(0),
       mCallingCancelWithinRun(false) {
   MOZ_ASSERT(aWorkerPrivate);
+
+  // An assortment of worker runnables have destructors that can perform
+  // recorded events at non-deterministic points. Leak these runnables to
+  // avoid these.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    AddRef();
+  }
 }
 
 bool WorkerRunnable::IsDebuggerRunnable() const { return false; }

--- a/gfx/2d/ScaledFontMac.cpp
+++ b/gfx/2d/ScaledFontMac.cpp
@@ -524,18 +524,10 @@ static CFDictionaryRef CreateVariationDictionaryOrNull(
   // This will typically be a very low value, so we just linear-search them.
   bool allDefaultValues = true;
 
-  // https://github.com/RecordReplay/backend/issues/4555
-  recordreplay::RecordReplayAssert("CreateVariationDictionaryOrNull #5 %d", (int)axisCount);
-
   for (CFIndex i = 0; i < axisCount; ++i) {
     // We sanity-check the axis info found in the CTFont, and bail out
     // (returning null) if it doesn't have the expected types.
     CFTypeRef axisInfo = CFArrayGetValueAtIndex(aCTAxesCache, i);
-
-    // https://github.com/RecordReplay/backend/issues/4555
-    recordreplay::RecordReplayAssert("CreateVariationDictionaryOrNull #6 %p %d %p",
-                                     aCTAxesCache, (int)i, axisInfo);
-
     if (CFDictionaryGetTypeID() != CFGetTypeID(axisInfo)) {
       return nullptr;
     }
@@ -543,11 +535,6 @@ static CFDictionaryRef CreateVariationDictionaryOrNull(
 
     CFTypeRef axisTag =
         CFDictionaryGetValue(axis, kCTFontVariationAxisIdentifierKey);
-
-    // https://github.com/RecordReplay/backend/issues/4555
-    recordreplay::RecordReplayAssert("CreateVariationDictionaryOrNull #7 %p %p",
-                                     axis, axisTag);
-
     if (!axisTag || CFGetTypeID(axisTag) != CFNumberGetTypeID()) {
       return nullptr;
     }

--- a/gfx/layers/client/TextureClient.cpp
+++ b/gfx/layers/client/TextureClient.cpp
@@ -1408,6 +1408,12 @@ TextureClient::TextureClient(TextureData* aData, TextureFlags aFlags,
     MOZ_ASSERT(!(mFlags & TextureFlags::NON_BLOCKING_READ_LOCK));
     EnableBlockingReadLock();
   }
+
+  // The destructor uses ordered locks and can run at inconsistent times when
+  // replaying, so we leak this class for now.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    ADDREF_MANUALLY(this);
+  }
 }
 
 bool TextureClient::CopyToTextureClient(TextureClient* aTarget,

--- a/gfx/layers/ipc/ISurfaceAllocator.cpp
+++ b/gfx/layers/ipc/ISurfaceAllocator.cpp
@@ -216,14 +216,6 @@ void FixedSizeSmallShmemSectionAllocator::ShrinkShmemSectionHeap() {
     return;
   }
 
-  // The shmem sections in use can vary between recording and replaying, leading
-  // to non-deterministic reads of the number of allocated blocks in each section.
-  // Never shrink the heap to avoid sending non-deterministic IPDL messages when
-  // the shmems are deallocated.
-  if (recordreplay::IsRecordingOrReplaying()) {
-    return;
-  }
-
   // The loop will terminate as we either increase i, or decrease size
   // every time through.
   size_t i = 0;

--- a/image/DecodedSurfaceProvider.cpp
+++ b/image/DecodedSurfaceProvider.cpp
@@ -27,6 +27,12 @@ DecodedSurfaceProvider::DecodedSurfaceProvider(NotNull<RasterImage*> aImage,
              "Use MetadataDecodingTask for metadata decodes");
   MOZ_ASSERT(mDecoder->IsFirstFrameDecode(),
              "Use AnimationSurfaceProvider for animation decodes");
+
+  // Leak when recording/replaying to avoid non-deterministic behavior
+  // in destructor.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    AddRef();
+  }
 }
 
 DecodedSurfaceProvider::~DecodedSurfaceProvider() { DropImageReference(); }

--- a/image/Decoder.cpp
+++ b/image/Decoder.cpp
@@ -70,10 +70,6 @@ Decoder::Decoder(RasterImage* aImage)
       mFinalizeFrames(true) {}
 
 Decoder::~Decoder() {
-  // Decoder destruction occurs at non-deterministic points even if events
-  // aren't disallowed, due to its threadsafe refcount.
-  recordreplay::AutoDisallowThreadEvents disallow;
-
   MOZ_ASSERT(mProgress == NoProgress || !mImage,
              "Destroying Decoder without taking all its progress changes");
   MOZ_ASSERT(mInvalidRect.IsEmpty() || !mImage,
@@ -88,7 +84,9 @@ Decoder::~Decoder() {
     qcms_profile_release(mInProfile);
   }
 
-  if (mImage && !NS_IsMainThread()) {
+  // For now we leak the image reference when recording/replaying rather than
+  // non-deterministically dispatch events to the main thread.
+  if (mImage && !NS_IsMainThread() && !recordreplay::IsRecordingOrReplaying()) {
     // Dispatch mImage to main thread to prevent it from being destructed by the
     // decode thread.
     SurfaceCache::ReleaseImageOnMainThread(mImage.forget());

--- a/image/SourceBuffer.cpp
+++ b/image/SourceBuffer.cpp
@@ -503,7 +503,7 @@ nsresult SourceBuffer::AppendFromInputStream(nsIInputStream* aInputStream,
 }
 
 void SourceBuffer::Complete(nsresult aStatus) {
-  MutexAutoLockMaybeEventsDisallowed lock(mMutex);
+  MutexAutoLock lock(mMutex);
 
   // When an error occurs internally (e.g. due to an OOM), we save the status.
   // This will indirectly trigger a failure higher up and that will call
@@ -535,7 +535,7 @@ void SourceBuffer::Complete(nsresult aStatus) {
 }
 
 bool SourceBuffer::IsComplete() {
-  MutexAutoLockMaybeEventsDisallowed lock(mMutex);
+  MutexAutoLock lock(mMutex);
   return bool(mStatus);
 }
 

--- a/image/SurfaceCache.cpp
+++ b/image/SurfaceCache.cpp
@@ -1707,9 +1707,9 @@ void SurfaceCache::UnlockEntries(const ImageKey aImageKey) {
 void SurfaceCache::RemoveImage(const ImageKey aImageKey) {
   RefPtr<ImageSurfaceCache> discard;
   {
-    OrderedStaticMutexAutoLockMaybeEventsDisallowed lock(sInstanceMutex);
+    OrderedStaticMutexAutoLock lock(sInstanceMutex);
     if (sInstance) {
-      discard = sInstance->RemoveImage(aImageKey, lock.get());
+      discard = sInstance->RemoveImage(aImageKey, lock);
     }
   }
 }
@@ -1824,9 +1824,9 @@ void SurfaceCache::ReleaseImageOnMainThread(
     return;
   }
 
-  OrderedStaticMutexAutoLockMaybeEventsDisallowed lock(sInstanceMutex);
+  OrderedStaticMutexAutoLock lock(sInstanceMutex);
   if (sInstance) {
-    sInstance->ReleaseImageOnMainThread(std::move(aImage), lock.get());
+    sInstance->ReleaseImageOnMainThread(std::move(aImage), lock);
   } else {
     NS_ReleaseOnMainThread("SurfaceCache::ReleaseImageOnMainThread",
                            std::move(aImage), /* aAlwaysProxy */ true);

--- a/image/imgRequestProxy.cpp
+++ b/image/imgRequestProxy.cpp
@@ -120,6 +120,12 @@ imgRequestProxy::imgRequestProxy()
       mHadDispatch(false) {
   /* member initializers and constructor code */
   LOG_FUNC(gImgLog, "imgRequestProxy::imgRequestProxy");
+
+  // For now we always leak imgRequestProxy objects when recording/replaying,
+  // to avoid non-deterministic behavior that can be triggered by the destructor.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    NS_ADDREF(this);
+  }
 }
 
 imgRequestProxy::~imgRequestProxy() {

--- a/image/imgTools.cpp
+++ b/image/imgTools.cpp
@@ -261,7 +261,13 @@ class ImageDecoderHelper final : public Runnable,
 
  private:
   ~ImageDecoderHelper() {
-    NS_ReleaseOnMainThread("ImageDecoderHelper::mCallback", mCallback.forget());
+    // Avoid posting runnables at non-deterministic points when recording/replaying.
+    if (recordreplay::IsRecordingOrReplaying()) {
+      // Leak reference.
+      (void)mCallback.forget().take();
+    } else {
+      NS_ReleaseOnMainThread("ImageDecoderHelper::mCallback", mCallback.forget());
+    }
   }
 
   RefPtr<image::Image> mImage;

--- a/ipc/glue/BackgroundImpl.cpp
+++ b/ipc/glue/BackgroundImpl.cpp
@@ -628,7 +628,12 @@ class ChildImpl::SendInitBackgroundRunnable final : public DiscardableRunnable {
         mMutex("SendInitBackgroundRunnable::mMutex"),
         mSentInitBackground(false),
         mSendInitfunc(std::move(aFunc)),
-        mThreadLocalIndex(aThreadLocalIndex) {}
+        mThreadLocalIndex(aThreadLocalIndex) {
+    // Avoid problematic calls in the destructor.
+    if (recordreplay::IsRecordingOrReplaying()) {
+      AddRef();
+    }
+  }
 
   ~SendInitBackgroundRunnable() = default;
 

--- a/ipc/glue/NodeController.h
+++ b/ipc/glue/NodeController.h
@@ -161,7 +161,7 @@ class NodeController final : public mojo::core::ports::NodeDelegate,
     NodeMap<nsTArray<PortRef>> mPendingMerges;
   };
 
-  DataMutex<State> mState{State(), "NodeController::mState", /* aOrdered */ true};
+  DataMutex<State> mState{"NodeController::mState"};
 };
 
 }  // namespace mozilla::ipc

--- a/ipc/glue/ProtocolUtils.cpp
+++ b/ipc/glue/ProtocolUtils.cpp
@@ -517,13 +517,6 @@ void IProtocol::SetManagerAndRegister(IProtocol* aManager, int32_t aId) {
 
 bool IProtocol::ChannelSend(IPC::Message* aMsg) {
   UniquePtr<IPC::Message> msg(aMsg);
-
-  // We don't have a way to send IPC messages at non-deterministic points.
-  // For now, silently discard the messages.
-  if (recordreplay::AreThreadEventsDisallowed()) {
-    return true;
-  }
-
   if (CanSend()) {
     // NOTE: This send call failing can only occur during toplevel channel
     // teardown. As this is an async call, this isn't reasonable to predict or

--- a/ipc/glue/SharedMemoryBasic_mach.mm
+++ b/ipc/glue/SharedMemoryBasic_mach.mm
@@ -534,6 +534,13 @@ static inline mach_vm_address_t toVMAddress(void* pointer) {
 bool SharedMemoryBasic::Create(size_t size) {
   MOZ_ASSERT(mPort == MACH_PORT_NULL, "already initialized");
 
+  if (recordreplay::HasDivergedFromRecording()) {
+    // Fake a port so we can avoid the system calls below.
+    mPort = 1;
+    Mapped(size);
+    return true;
+  }
+
   memory_object_size_t memoryObjectSize = round_page(size);
 
   kern_return_t kr =

--- a/js/xpconnect/src/SandboxPrivate.h
+++ b/js/xpconnect/src/SandboxPrivate.h
@@ -37,6 +37,10 @@ class SandboxPrivate : public nsIGlobalObject,
     nsIScriptObjectPrincipal* sop =
         static_cast<nsIScriptObjectPrincipal*>(sbp.forget().take());
     JS::SetPrivate(global, sop);
+
+    // Never collect the global while recording or replaying, so that the
+    // principal reference is not released at a non-deterministic point.
+    mozilla::recordreplay::HoldJSObject(global);
   }
 
   static SandboxPrivate* GetPrivate(JSObject* obj) {

--- a/js/xpconnect/src/XPCInlines.h
+++ b/js/xpconnect/src/XPCInlines.h
@@ -318,7 +318,13 @@ inline void XPCWrappedNative::SweepTearOffs() {
     // If this tearoff does not have a live dedicated JSObject,
     // then let's recycle it.
     if (!to->GetJSObjectPreserveColor()) {
-      to->SetNative(nullptr);
+      RefPtr<nsISupports> native = to->TakeNative();
+      if (native && mozilla::recordreplay::IsRecordingOrReplaying()) {
+        // Finalization must be deferred while recording/replaying to
+        // match the RecordReplayRegisterDeferredFinalizeThing call
+        // when the tearoff was initialized.
+        mozilla::DeferredFinalize(native.forget().take());
+      }
       to->SetInterface(nullptr);
     }
   }

--- a/js/xpconnect/src/XPCJSRuntime.cpp
+++ b/js/xpconnect/src/XPCJSRuntime.cpp
@@ -759,6 +759,11 @@ void XPCJSRuntime::EndCycleCollectionCallback(CycleCollectorResults& aResults) {
 }
 
 void XPCJSRuntime::DispatchDeferredDeletion(bool aContinuation, bool aPurge) {
+  // References held by JS objects are not released when recording/replaying.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    return;
+  }
+
   mAsyncSnowWhiteFreer->Start(aContinuation, aPurge);
 }
 

--- a/js/xpconnect/src/XPCWrappedNative.cpp
+++ b/js/xpconnect/src/XPCWrappedNative.cpp
@@ -548,6 +548,10 @@ inline void XPCWrappedNative::SetFlatJSObject(JSObject* object) {
 
   mFlatJSObject = object;
   mFlatJSObject.setFlags(FLAT_JS_OBJECT_VALID);
+
+  // Never collect the wrapper object while recording or replaying, to avoid
+  // non-deterministically releasing references during finalization.
+  recordreplay::HoldJSObject(object);
 }
 
 inline void XPCWrappedNative::UnsetFlatJSObject() {

--- a/js/xpconnect/src/XPCWrappedNativeProto.cpp
+++ b/js/xpconnect/src/XPCWrappedNativeProto.cpp
@@ -59,6 +59,10 @@ bool XPCWrappedNativeProto::Init(JSContext* cx, nsIXPCScriptable* scriptable) {
   bool success = !!mJSProtoObject;
   if (success) {
     JS::SetPrivate(mJSProtoObject, this);
+
+    // Never collect the proto object while recording or replaying, to avoid
+    // non-deterministically releasing references during finalization.
+    recordreplay::HoldJSObject(mJSProtoObject);
   }
 
   return success;

--- a/mfbt/RecordReplay.cpp
+++ b/mfbt/RecordReplay.cpp
@@ -62,6 +62,7 @@ namespace recordreplay {
   Macro(InternalRecordReplayBytes, (const char* aWhy, void* aData, size_t aSize), \
         (aWhy, aData, aSize))                                                  \
   Macro(InternalInvalidateRecording, (const char* aWhy), (aWhy))               \
+  Macro(InternalHoldJSObject, (void* aJSObj), (aJSObj))                        \
   Macro(InternalRecordReplayAssert, (const char* aFormat, va_list aArgs),      \
         (aFormat, aArgs))                                                      \
   Macro(InternalRecordReplayAssertBytes, (const void* aData, size_t aSize),    \

--- a/mfbt/RecordReplay.h
+++ b/mfbt/RecordReplay.h
@@ -140,6 +140,15 @@ static inline void RecordReplayBytes(const char* aWhy, void* aData, size_t aSize
 // see 'Unrecordable Executions' in the URL above.
 static inline void InvalidateRecording(const char* aWhy);
 
+// Prevent a JS object from ever being collected while recording or replaying.
+// GC behavior is non-deterministic when recording/replaying, and preventing
+// an object from being collected ensures that finalizers which might interact
+// with the recording will not execute. "aJSObj" must be a JSObject* pointer,
+// but we can't include JSObject's header here and we can't forward-declare it
+// due to some peculiarities with the compiler's visibility attributes.
+// See https://bugzilla.mozilla.org/show_bug.cgi?id=1426865
+static inline void HoldJSObject(void* aJSObj);
+
 // Some devtools operations which execute in a replaying process can cause code
 // to run which did not run while recording. For example, the JS debugger can
 // run arbitrary JS while paused at a breakpoint, by doing an eval(). In such
@@ -259,7 +268,7 @@ MFBT_API bool ShouldUpdateProgressCounter(const char* aURL);
 // Define a RecordReplayControl object on the specified global object, with
 // methods specialized to the current recording/replaying process
 // kind. "aCx" must be a JSContext* pointer, and "aObj" must be a JSObject*
-// pointer.
+// pointer, as with HoldJSObject above.
 MFBT_API bool DefineRecordReplayControlObject(void* aCx, void* aObj);
 
 // Notify the infrastructure that some URL which contains JavaScript or CSS is
@@ -405,6 +414,7 @@ MOZ_MAKE_RECORD_REPLAY_WRAPPER(HasDivergedFromRecording, bool, false, (), ())
 MOZ_MAKE_RECORD_REPLAY_WRAPPER(IsUnhandledDivergenceAllowed, bool, true, (), ())
 MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(InvalidateRecording, (const char* aWhy),
                                     (aWhy))
+MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(HoldJSObject, (void* aJSObj), (aJSObj))
 MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(RecordReplayAssertBytes,
                                     (const void* aData, size_t aSize),
                                     (aData, aSize))

--- a/netwerk/ipc/ChannelEventQueue.cpp
+++ b/netwerk/ipc/ChannelEventQueue.cpp
@@ -161,8 +161,6 @@ void ChannelEventQueue::ResumeInternal() {
             mOwner(aOwner) {}
 
       NS_IMETHOD Run() override {
-        // https://github.com/RecordReplay/backend/issues/4307
-        recordreplay::RecordReplayAssert("CompleteResumeRunnable::Run");
         mQueue->CompleteResume();
         return NS_OK;
       }
@@ -175,15 +173,8 @@ void ChannelEventQueue::ResumeInternal() {
     };
 
     if (!mOwner) {
-      // https://github.com/RecordReplay/backend/issues/4307
-      // mOwner can be unset non-deterministically, so make sure we create the
-      // CompleteResume runnable at a consistent point.
-      recordreplay::RecordReplayAssert("ChannelEventQueue::ResumeInternal NoOwner");
       return;
     }
-
-    // https://github.com/RecordReplay/backend/issues/4307
-    recordreplay::RecordReplayAssert("ChannelEventQueue::ResumeInternal CompleteResume");
 
     // Worker thread requires a CancelableRunnable.
     RefPtr<Runnable> event = new CompleteResumeRunnable(this, mOwner);

--- a/netwerk/ipc/ChannelEventQueue.h
+++ b/netwerk/ipc/ChannelEventQueue.h
@@ -148,7 +148,7 @@ class ChannelEventQueue final {
   void Resume();
 
   void NotifyReleasingOwner() {
-    MutexAutoLockMaybeEventsDisallowed lock(mMutex);
+    MutexAutoLock lock(mMutex);
     mOwner = nullptr;
   }
 

--- a/netwerk/protocol/http/HttpChannelChild.cpp
+++ b/netwerk/protocol/http/HttpChannelChild.cpp
@@ -103,13 +103,14 @@ HttpChannelChild::HttpChannelChild()
   // We require that the parent cookie service actor exists while
   // processing HTTP responses.
   RefPtr<CookieServiceChild> cookieService = CookieServiceChild::GetSingleton();
+
+  if (recordreplay::IsRecordingOrReplaying()) {
+    // Leak this to avoid non-deterministic behavior in destructor.
+    AddRef();
+  }
 }
 
 HttpChannelChild::~HttpChannelChild() {
-  // Destruction can occur at non-deterministic points even if events aren't
-  // currently disallowed.
-  recordreplay::AutoDisallowThreadEvents disallow;
-
   LOG(("Destroying HttpChannelChild @%p\n", this));
 
 #ifdef MOZ_DIAGNOSTIC_ASSERT_ENABLED
@@ -157,8 +158,13 @@ void HttpChannelChild::ReleaseMainThreadOnlyReferences() {
     return;
   }
 
-  NS_ReleaseOnMainThread("HttpChannelChild::mRedirectChannelChild",
-                         mRedirectChannelChild.forget());
+  if (recordreplay::IsRecordingOrReplaying()) {
+    // Leak reference to avoid non-deterministic dtor call.
+    (void)mRedirectChannelChild.forget().take();
+  } else {
+    NS_ReleaseOnMainThread("HttpChannelChild::mRedirectChannelChild",
+                           mRedirectChannelChild.forget());
+  }
 }
 //-----------------------------------------------------------------------------
 // HttpChannelChild::nsISupports

--- a/parser/html/nsHtml5StreamParser.cpp
+++ b/parser/html/nsHtml5StreamParser.cpp
@@ -1520,13 +1520,11 @@ class nsHtml5RequestStopper : public Runnable {
 
  public:
   explicit nsHtml5RequestStopper(nsHtml5StreamParser* aStreamParser)
-      : Runnable("nsHtml5RequestStopper"), mStreamParser(aStreamParser) {}
-
-  ~nsHtml5RequestStopper() {
-    // This can be destroyed at non-deterministic points, so disallow events
-    // while the stream parser pointer is destroyed.
-    recordreplay::AutoDisallowThreadEvents disallow;
-    mStreamParser = nullptr;
+      : Runnable("nsHtml5RequestStopper"), mStreamParser(aStreamParser) {
+    if (recordreplay::IsRecordingOrReplaying()) {
+      // Leak to avoid non-deterministic behavior in destructor.
+      AddRef();
+    }
   }
 
   NS_IMETHOD Run() override {

--- a/parser/html/nsHtml5StreamParserPtr.h
+++ b/parser/html/nsHtml5StreamParserPtr.h
@@ -42,7 +42,9 @@ class nsHtml5StreamParserPtr {
 
  public:
   ~nsHtml5StreamParserPtr() {
-    if (mRawPtr) {
+    // Leak the reference when recording/replaying to avoid dispatching
+    // runnables at non-deterministic points.
+    if (mRawPtr && !mozilla::recordreplay::IsRecordingOrReplaying()) {
       release(mRawPtr);
     }
   }

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -548,6 +548,14 @@ MOZ_EXPORT void* RecordReplayInterface_InternalIndexThing(size_t aId) {
   return gIdPointer(aId);
 }
 
+MOZ_EXPORT void RecordReplayInterface_InternalHoldJSObject(void* aJSObj) {
+  if (aJSObj) {
+    JSContext* cx = dom::danger::GetJSContext();
+    JS::PersistentRootedObject* root = new JS::PersistentRootedObject(cx);
+    *root = static_cast<JSObject*>(aJSObj);
+  }
+}
+
 MOZ_EXPORT void RecordReplayInterface_InternalAssertScriptedCaller(const char* aWhy) {
   JS::AutoFilename filename;
   unsigned lineno;

--- a/xpcom/base/CycleCollectedJSContext.cpp
+++ b/xpcom/base/CycleCollectedJSContext.cpp
@@ -822,6 +822,12 @@ void FinalizationRegistryCleanup::QueueCallback(JSFunction* aDoCleanup,
 
 void FinalizationRegistryCleanup::QueueCallback(JSFunction* aDoCleanup,
                                                 JSObject* aIncumbentGlobal) {
+  // FinalizationRegistry callbacks are not invoked when recording/replaying,
+  // as the invocations can happen at non-deterministic points in the recording.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    return;
+  }
+
   bool firstCallback = mCallbacks.empty();
 
   MOZ_ALWAYS_TRUE(mCallbacks.append(Callback{aDoCleanup, aIncumbentGlobal}));

--- a/xpcom/base/CycleCollectedJSRuntime.cpp
+++ b/xpcom/base/CycleCollectedJSRuntime.cpp
@@ -1711,6 +1711,11 @@ IncrementalFinalizeRunnable::Run() {
 
 void CycleCollectedJSRuntime::FinalizeDeferredThings(
     CycleCollectedJSContext::DeferredFinalizeType aType) {
+  // Never do deferred finalization when recording/replaying.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    return;
+  }
+
   /*
    * If the previous GC created a runnable to finalize objects
    * incrementally, and if it hasn't finished yet, finish it now. We

--- a/xpcom/base/StaticMutex.h
+++ b/xpcom/base/StaticMutex.h
@@ -85,23 +85,6 @@ typedef detail::BaseAutoUnlock<StaticMutex&> StaticMutexAutoUnlock;
 typedef detail::BaseAutoLock<OrderedStaticMutex&> OrderedStaticMutexAutoLock;
 typedef detail::BaseAutoUnlock<OrderedStaticMutex&> OrderedStaticMutexAutoUnlock;
 
-// Locks an ordered static mutex. When events are disallowed on the current thread,
-// the lock will be unordered and could occur at a different point when replaying.
-class OrderedStaticMutexAutoLockMaybeEventsDisallowed {
- public:
-  OrderedStaticMutexAutoLockMaybeEventsDisallowed(OrderedStaticMutex& aMutex) {
-    if (recordreplay::AreThreadEventsDisallowed()) {
-      recordreplay::AutoPassThroughThreadEvents pt;
-      mLock.emplace(aMutex);
-    } else {
-      mLock.emplace(aMutex);
-    }
-  }
-  OrderedStaticMutexAutoLock& get() { return mLock.ref(); }
- private:
-  Maybe<OrderedStaticMutexAutoLock> mLock;
-};
-
 }  // namespace mozilla
 
 #endif

--- a/xpcom/base/nsCycleCollector.cpp
+++ b/xpcom/base/nsCycleCollector.cpp
@@ -2429,6 +2429,11 @@ class SnowWhiteKiller : public TraceCallbacks {
 
  public:
   bool Visit(nsPurpleBuffer& aBuffer, nsPurpleBufferEntry* aEntry) {
+    // The cycle collector does not collect anything when recording/replaying.
+    if (recordreplay::IsRecordingOrReplaying()) {
+      return true;
+    }
+
     if (mBudget) {
       if (mBudget->isOverBudget()) {
         return false;
@@ -2639,6 +2644,11 @@ void nsCycleCollector::ForgetSkippable(js::SliceBudget& aBudget,
   // If we remove things from the purple buffer during graph building, we may
   // lose track of an object that was mutated during graph building.
   MOZ_ASSERT(IsIdle());
+
+  // The cycle collector does not collect anything when recording/replaying.
+  if (recordreplay::IsRecordingOrReplaying()) {
+    return;
+  }
 
   if (mCCJSRuntime) {
     mCCJSRuntime->PrepareForForgetSkippable();
@@ -3370,7 +3380,9 @@ bool nsCycleCollector::Collect(ccType aCCType, SliceBudget& aBudget,
   CheckThreadSafety();
 
   // This can legitimately happen in a few cases. See bug 383651.
-  if (mActivelyCollecting || mFreeingSnowWhite) {
+  // When recording/replaying we do not collect cycles.
+  if (mActivelyCollecting || mFreeingSnowWhite ||
+      recordreplay::IsRecordingOrReplaying()) {
     return false;
   }
   mActivelyCollecting = true;
@@ -3736,6 +3748,9 @@ CycleCollectedJSContext* CycleCollectedJSContext::Get() {
 MOZ_NEVER_INLINE static void SuspectAfterShutdown(
     void* aPtr, nsCycleCollectionParticipant* aCp,
     nsCycleCollectingAutoRefCnt* aRefCnt, bool* aShouldDelete) {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    return;
+  }
   if (aRefCnt->get() == 0) {
     if (!aShouldDelete) {
       // The CC is shut down, so we can't be in the middle of an ICC.
@@ -3793,7 +3808,9 @@ uint32_t nsCycleCollector_suspectedCount() {
   // We should have started the cycle collector by now.
   MOZ_ASSERT(data);
 
-  if (!data->mCollector) {
+  // When recording/replaying we do not collect cycles. Return zero here so
+  // that callers behave consistently between recording and replaying.
+  if (!data->mCollector || recordreplay::IsRecordingOrReplaying()) {
     return 0;
   }
 

--- a/xpcom/ds/nsHashPropertyBag.h
+++ b/xpcom/ds/nsHashPropertyBag.h
@@ -7,6 +7,7 @@
 #ifndef nsHashPropertyBag_h___
 #define nsHashPropertyBag_h___
 
+#include "mozilla/RecordReplay.h"
 #include "nsIVariant.h"
 #include "nsIWritablePropertyBag.h"
 #include "nsIWritablePropertyBag2.h"
@@ -36,7 +37,12 @@ class nsHashPropertyBagBase : public nsIWritablePropertyBag,
 
 class nsHashPropertyBag : public nsHashPropertyBagBase {
  public:
-  nsHashPropertyBag() = default;
+  nsHashPropertyBag() {
+    // Avoid destroying this object when recording/replaying. See bug 1497299.
+    if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+      AddRef();
+    }
+  }
   NS_DECL_THREADSAFE_ISUPPORTS
 
  protected:

--- a/xpcom/threads/Monitor.h
+++ b/xpcom/threads/Monitor.h
@@ -85,23 +85,6 @@ class MOZ_STACK_CLASS MonitorAutoLock {
   Monitor* mMonitor;
 };
 
-// Locks an ordered monitor. When events are disallowed on the current thread,
-// the lock will be unordered and could occur at a different point when replaying.
-class MonitorAutoLockMaybeEventsDisallowed {
- public:
-  MonitorAutoLockMaybeEventsDisallowed(Monitor& aMonitor) {
-    if (recordreplay::AreThreadEventsDisallowed()) {
-      recordreplay::AutoPassThroughThreadEvents pt;
-      mLock.emplace(aMonitor);
-    } else {
-      mLock.emplace(aMonitor);
-    }
-  }
-  MonitorAutoLock& get() { return mLock.ref(); }
- private:
-  Maybe<MonitorAutoLock> mLock;
-};
-
 /**
  * Unlock the monitor for the lexical scope instances of this class
  * are bound to (except for MonitorAutoLock in nested scopes).

--- a/xpcom/threads/Mutex.h
+++ b/xpcom/threads/Mutex.h
@@ -8,7 +8,6 @@
 #define mozilla_Mutex_h
 
 #include "mozilla/BlockingResourceBase.h"
-#include "mozilla/Maybe.h"
 #include "mozilla/PlatformMutex.h"
 #include "mozilla/RecordReplay.h"
 #include "nsISupports.h"
@@ -216,23 +215,6 @@ BaseAutoLock(MutexType&) -> BaseAutoLock<MutexType&>;
 
 typedef detail::BaseAutoLock<Mutex&> MutexAutoLock;
 typedef detail::BaseAutoLock<OffTheBooksMutex&> OffTheBooksMutexAutoLock;
-
-// Locks an ordered mutex. When events are disallowed on the current thread,
-// the lock will be unordered and could occur at a different point when replaying.
-class MutexAutoLockMaybeEventsDisallowed {
- public:
-  MutexAutoLockMaybeEventsDisallowed(Mutex& aMutex) {
-    if (recordreplay::AreThreadEventsDisallowed()) {
-      recordreplay::AutoPassThroughThreadEvents pt;
-      mLock.emplace(aMutex);
-    } else {
-      mLock.emplace(aMutex);
-    }
-  }
-  MutexAutoLock& get() { return mLock.ref(); }
- private:
-  Maybe<MutexAutoLock> mLock;
-};
 
 namespace detail {
 /**

--- a/xpcom/threads/ReentrantMonitor.h
+++ b/xpcom/threads/ReentrantMonitor.h
@@ -198,29 +198,6 @@ class MOZ_STACK_CLASS ReentrantMonitorAutoEnter {
   mozilla::ReentrantMonitor* mReentrantMonitor;
 };
 
-// Enters an ordered monitor. When events are disallowed on the current thread,
-// the enter will be unordered and could occur at a different point when replaying.
-class ReentrantMonitorAutoEnterMaybeEventsDisallowed {
- public:
-  ReentrantMonitorAutoEnterMaybeEventsDisallowed(ReentrantMonitor& aMonitor) {
-    if (recordreplay::AreThreadEventsDisallowed()) {
-      recordreplay::AutoPassThroughThreadEvents pt;
-      mEnter.emplace(aMonitor);
-    } else {
-      mEnter.emplace(aMonitor);
-    }
-  }
-  ~ReentrantMonitorAutoEnterMaybeEventsDisallowed() {
-    if (recordreplay::AreThreadEventsDisallowed()) {
-      recordreplay::AutoPassThroughThreadEvents pt;
-      mEnter.reset();
-    }
-  }
-  ReentrantMonitorAutoEnter& get() { return mEnter.ref(); }
- private:
-  Maybe<ReentrantMonitorAutoEnter> mEnter;
-};
-
 /**
  * ReentrantMonitorAutoExit
  * Exit the ReentrantMonitor when it enters scope, and enters it when it leaves

--- a/xpcom/threads/ThreadEventQueue.h
+++ b/xpcom/threads/ThreadEventQueue.h
@@ -81,9 +81,6 @@ class ThreadEventQueue final : public SynchronizedEventQueue {
   bool mEventsAreDoomed = false;
   nsCOMPtr<nsIThreadObserver> mObserver;
   bool mIsMainThread;
-
-  Mutex mLockNonDeterministic;
-  EventQueue mBaseQueueNonDeterministic;
 };
 
 }  // namespace mozilla

--- a/xpcom/threads/ThrottledEventQueue.cpp
+++ b/xpcom/threads/ThrottledEventQueue.cpp
@@ -103,9 +103,6 @@ class ThrottledEventQueue::Inner final : public nsISupports {
   // emptied.
   EventQueueSized<64> mEventQueue;
 
-  mutable Mutex mMutexNonDeterministic;
-  EventQueue mEventQueueNonDeterministic;
-
   // The event target we dispatch our events (actually, just our Executor) to.
   //
   // Written only during construction. Readable by any thread without locking.
@@ -129,7 +126,6 @@ class ThrottledEventQueue::Inner final : public nsISupports {
                  uint32_t aPriority)
       : mMutex("ThrottledEventQueue", /* aOrdered */ true),
         mIdleCondVar(mMutex, "ThrottledEventQueue:Idle"),
-        mMutexNonDeterministic("ThrottledEventQueueNonDeterministic"),
         mBaseTarget(aBaseTarget),
         mName(aName),
         mPriority(aPriority),
@@ -212,21 +208,6 @@ class ThrottledEventQueue::Inner final : public nsISupports {
     mBaseTarget->IsOnCurrentThread(&currentThread);
     MOZ_ASSERT(currentThread);
 #endif
-
-    // Run any pending non-deterministic events.
-    if (recordreplay::IsRecordingOrReplaying()) {
-      recordreplay::AutoDisallowThreadEvents disallow;
-      MutexAutoLock lock(mMutexNonDeterministic);
-      while (true) {
-        TimeDuration delay;
-        nsCOMPtr<nsIRunnable> event = mEventQueueNonDeterministic.GetEvent(lock, &delay);
-        if (event) {
-          event->Run();
-        } else {
-          break;
-        }
-      }
-    }
 
     {
       MutexAutoLock lock(mMutex);
@@ -354,13 +335,6 @@ class ThrottledEventQueue::Inner final : public nsISupports {
 
   nsresult Dispatch(already_AddRefed<nsIRunnable> aEvent, uint32_t aFlags) {
     MOZ_ASSERT(aFlags == NS_DISPATCH_NORMAL || aFlags == NS_DISPATCH_AT_END);
-
-    if (recordreplay::AreThreadEventsDisallowed()) {
-      MutexAutoLock lock(mMutexNonDeterministic);
-      nsCOMPtr<nsIRunnable> event(aEvent);
-      mEventQueueNonDeterministic.PutEvent(event.forget(), EventQueuePriority::Normal, lock);
-      return NS_OK;
-    }
 
     // Any thread
     MutexAutoLock lock(mMutex);

--- a/xpcom/threads/TimerThread.cpp
+++ b/xpcom/threads/TimerThread.cpp
@@ -533,7 +533,7 @@ nsresult TimerThread::AddTimer(nsTimerImpl* aTimer) {
 }
 
 nsresult TimerThread::RemoveTimer(nsTimerImpl* aTimer) {
-  MonitorAutoLockMaybeEventsDisallowed lock(mMonitor);
+  MonitorAutoLock lock(mMonitor);
 
   // Remove the timer from our array.  Tell callers that aTimer was not found
   // by returning NS_ERROR_NOT_AVAILABLE.
@@ -542,8 +542,8 @@ nsresult TimerThread::RemoveTimer(nsTimerImpl* aTimer) {
     return NS_ERROR_NOT_AVAILABLE;
   }
 
-  // Awaken the timer thread, unless thread events are disallowed.
-  if (mWaiting && !recordreplay::AreThreadEventsDisallowed()) {
+  // Awaken the timer thread.
+  if (mWaiting) {
     mNotified = true;
     mMonitor.Notify();
   }

--- a/xpcom/threads/nsProxyRelease.h
+++ b/xpcom/threads/nsProxyRelease.h
@@ -268,6 +268,10 @@ class MOZ_IS_SMARTPTR_TO_REFCOUNTED nsMainThreadPtrHolder final {
     if (NS_IsMainThread()) {
       NS_IF_RELEASE(mRawPtr);
     } else if (mRawPtr) {
+      if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+        // Avoid posting runnables at non-deterministic points.
+        return;
+      }
       if (!mMainThreadEventTarget) {
         mMainThreadEventTarget = do_GetMainThread();
       }

--- a/xpcom/threads/nsThreadPool.cpp
+++ b/xpcom/threads/nsThreadPool.cpp
@@ -62,7 +62,6 @@ nsThreadPool::nsThreadPool()
     : Runnable("nsThreadPool"),
       mMutex("[nsThreadPool.mMutex]", /* aOrdered */ true),
       mEventsAvailable(mMutex, "[nsThreadPool.mEventsAvailable]"),
-      mMutexNonDeterministic("[nsThreadPool.mMutexNonDeterministic]"),
       mThreadLimit(DEFAULT_THREAD_LIMIT),
       mIdleThreadLimit(DEFAULT_IDLE_THREAD_LIMIT),
       mIdleThreadTimeout(DEFAULT_IDLE_THREAD_TIMEOUT),
@@ -91,16 +90,6 @@ nsresult nsThreadPool::PutEvent(nsIRunnable* aEvent) {
 nsresult nsThreadPool::PutEvent(already_AddRefed<nsIRunnable> aEvent,
                                 uint32_t aFlags) {
   // Avoid spawning a new thread while holding the event queue lock...
-
-  // Events dispatched while record/replay thread events are disallowed are
-  // happening at a non-deterministic point, and use a separate thread pool.
-  if (recordreplay::AreThreadEventsDisallowed()) {
-    MOZ_RELEASE_ASSERT(!aFlags);
-    MutexAutoLock lock(mMutexNonDeterministic);
-    nsCOMPtr<nsIRunnable> event(aEvent);
-    mEventsNonDeterministic.PutEvent(event.forget(), EventQueuePriority::Normal, lock);
-    return NS_OK;
-  }
 
   bool spawnThread = false;
   uint32_t stackSize = 0;
@@ -252,17 +241,6 @@ nsThreadPool::Run() {
   gCurrentThreadPool.set(this);
 
   do {
-    // Run any pending non-deterministic events first.
-    {
-      recordreplay::AutoDisallowThreadEvents disallow;
-      MutexAutoLock lock(mMutexNonDeterministic);
-      TimeDuration delay;
-      nsCOMPtr<nsIRunnable> event = mEventsNonDeterministic.GetEvent(lock, &delay);
-      if (event) {
-        event->Run();
-      }
-    }
-
     nsCOMPtr<nsIRunnable> event;
     TimeDuration delay;
     {

--- a/xpcom/threads/nsThreadPool.h
+++ b/xpcom/threads/nsThreadPool.h
@@ -40,8 +40,6 @@ class nsThreadPool final : public mozilla::Runnable, public nsIThreadPool {
   mozilla::Mutex mMutex;
   mozilla::CondVar mEventsAvailable;
   mozilla::EventQueue mEvents;
-  mozilla::Mutex mMutexNonDeterministic;
-  mozilla::EventQueue mEventsNonDeterministic;
   uint32_t mThreadLimit;
   uint32_t mIdleThreadLimit;
   uint32_t mIdleThreadTimeout;

--- a/xpcom/threads/nsThreadUtils.cpp
+++ b/xpcom/threads/nsThreadUtils.cpp
@@ -376,12 +376,6 @@ NS_INTERFACE_MAP_END_INHERITING(Runnable)
 extern nsresult NS_DispatchToThreadQueue(already_AddRefed<nsIRunnable>&& aEvent,
                                          uint32_t aTimeout, nsIThread* aThread,
                                          EventQueuePriority aQueue) {
-  // Ignore the timeout for non-deterministic events when recording/replaying,
-  // dispatch the event with a normal priority.
-  if (recordreplay::AreThreadEventsDisallowed()) {
-    return NS_DispatchToThreadQueue(std::move(aEvent), aThread, EventQueuePriority::Normal);
-  }
-
   nsCOMPtr<nsIRunnable> event(std::move(aEvent));
   NS_ENSURE_TRUE(event, NS_ERROR_INVALID_ARG);
   MOZ_ASSERT(aQueue == EventQueuePriority::Idle ||

--- a/xpcom/threads/nsTimerImpl.cpp
+++ b/xpcom/threads/nsTimerImpl.cpp
@@ -121,7 +121,7 @@ nsresult TimerThreadWrapper::AddTimer(nsTimerImpl* aTimer) {
 }
 
 nsresult TimerThreadWrapper::RemoveTimer(nsTimerImpl* aTimer) {
-  mozilla::OrderedStaticMutexAutoLockMaybeEventsDisallowed lock(sMutex);
+  mozilla::OrderedStaticMutexAutoLock lock(sMutex);
   if (mThread) {
     return mThread->RemoveTimer(aTimer);
   }


### PR DESCRIPTION
Alternative to https://github.com/RecordReplay/gecko-dev/pull/771 which backs out https://github.com/RecordReplay/gecko-dev/pull/765 entirely.