### PR TITLE
Use the name of the prototype's constructor as an object's className (devtools#5570)

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -1665,7 +1665,12 @@ function createProtocolObject(objectId, level) {
     return { objectId, className: "BadObjectId" };
   }
 
-  const className = getClassName(obj)
+  let className = getClassName(obj);
+  if (className === "Object") {
+    try {
+      className = obj.proto?.getProperty("constructor").return?.name || className;
+    } catch {}
+  }
   let preview;
   if (level != "none") {
     preview = new ProtocolObjectPreview(obj, level).fill();


### PR DESCRIPTION
`getClassName()` uses `Debugger.Object.prototype.class` to get the classname, but for user-defined classes it will return `Object` (see RecordReplay/devtools#5570). With this PR we try to use the prototype's constructor name instead.
- I didn't change the `getClassName()` function itself because there is another use of that function for choosing a previewer for the object and I didn't want to disrupt that
- I wrapped this in a `try ... catch` block because according to the [documentation](https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html) `Debugger.Object.prototype.proto` can throw for "exotic" objects