### PR TITLE
Disallow events in nsPipeInputStream destructor

### DIFF
--- a/xpcom/io/nsPipe3.cpp
+++ b/xpcom/io/nsPipe3.cpp
@@ -1550,7 +1550,12 @@ nsresult nsPipeInputStream::Status() const {
   return Status(mon);
 }
 
-nsPipeInputStream::~nsPipeInputStream() { Close(); }
+nsPipeInputStream::~nsPipeInputStream() {
+  // The destructor can run at non-deterministic points due to threadsafe refcounts.
+  recordreplay::AutoDisallowThreadEvents disallow;
+
+  Close();
+}
 
 //-----------------------------------------------------------------------------
 // nsPipeOutputStream methods:


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/5115