### PR TITLE
Never free shmem sections when recording/replaying

### DIFF
--- a/gfx/layers/client/TextureClient.cpp
+++ b/gfx/layers/client/TextureClient.cpp
@@ -736,6 +736,10 @@ void TextureClient::Unlock() {
 }
 
 void TextureClient::EnableReadLock() {
+  // https://github.com/RecordReplay/backend/issues/5113
+  recordreplay::RecordReplayAssert("TextureClient::EnableReadLock Start id=%zu hasReadLock=%d",
+                                   recordreplay::ThingIndex(this), !!mReadLock);
+
   if (!mReadLock) {
     if (mAllocator->GetTileLockAllocator()) {
       mReadLock = NonBlockingTextureReadLock::Create(mAllocator);
@@ -763,6 +767,8 @@ bool TextureClient::OnForwardedToHost() {
 }
 
 TextureClient::~TextureClient() {
+  recordreplay::UnregisterThing(this);
+
   // TextureClients should be kept alive while there are references on the
   // paint thread.
   MOZ_ASSERT(mPaintThreadRefs == 0);
@@ -1195,6 +1201,9 @@ already_AddRefed<TextureClient> TextureClient::CreateForDrawing(
     gfx::IntSize aSize, KnowsCompositor* aKnowsCompositor,
     BackendSelector aSelector, TextureFlags aTextureFlags,
     TextureAllocationFlags aAllocFlags) {
+  // https://github.com/RecordReplay/backend/issues/5113
+  recordreplay::RecordReplayAssert("TextureClient::CreateForDrawing Start");
+
   LayersBackend layersBackend = aKnowsCompositor->GetCompositorBackendType();
   gfx::BackendType moz2DBackend =
       BackendTypeForBackendSelector(layersBackend, aSelector);
@@ -1311,6 +1320,9 @@ already_AddRefed<TextureClient> TextureClient::CreateForRawBufferAccess(
     gfx::IntSize aSize, gfx::BackendType aMoz2DBackend,
     LayersBackend aLayersBackend, TextureFlags aTextureFlags,
     TextureAllocationFlags aAllocFlags) {
+  // https://github.com/RecordReplay/backend/issues/5113
+  recordreplay::RecordReplayAssert("TextureClient::CreateForRawBufferAccess Start");
+
   // also test the validity of aAllocator
   if (!aAllocator || !aAllocator->IPCOpen()) {
     return nullptr;
@@ -1398,6 +1410,8 @@ TextureClient::TextureClient(TextureData* aData, TextureFlags aFlags,
       mPoolTracker(nullptr)
 #endif
 {
+  recordreplay::RegisterThing(this);
+
   mData->FillInfo(mInfo);
   mFlags |= mData->GetTextureFlags();
 

--- a/gfx/layers/client/TextureClientPool.cpp
+++ b/gfx/layers/client/TextureClientPool.cpp
@@ -97,6 +97,10 @@ already_AddRefed<TextureClient> TextureClientPool::GetTextureClient() {
   // Try to fetch a client from the pool
   RefPtr<TextureClient> textureClient;
 
+  // https://github.com/RecordReplay/backend/issues/5113
+  recordreplay::RecordReplayAssert("TextureClientPool::GetTextureClient Start textureClientsEmpty=%d",
+                                   mTextureClients.empty());
+
   // We initially allocate mInitialPoolSize for our pool. If we run
   // out of TextureClients, we allocate additional TextureClients to try and
   // keep around mPoolUnusedSize

--- a/gfx/layers/client/TiledContentClient.cpp
+++ b/gfx/layers/client/TiledContentClient.cpp
@@ -497,7 +497,14 @@ static already_AddRefed<TextureClient> CreateBackBufferTexture(
     aAllocator->ReportClientLost();
   }
 
+  // https://github.com/RecordReplay/backend/issues/5113
+  recordreplay::RecordReplayAssert("CreateBackBufferTexture Start");
+
   RefPtr<TextureClient> texture = aAllocator->GetTextureClient();
+
+  // https://github.com/RecordReplay/backend/issues/5113
+  recordreplay::RecordReplayAssert("CreateBackBufferTexture HaveTexture id=%zu",
+                                   recordreplay::ThingIndex(texture));
 
   if (!texture) {
     gfxCriticalError() << "[Tiling:Client] Failed to allocate a TextureClient";


### PR DESCRIPTION
Diagnostics and a tentative fix for https://github.com/RecordReplay/backend/issues/5113.  Before https://github.com/RecordReplay/backend/issues/4307 we used to leak all TextureClients, which I think prevented shmem sections from ever getting freed.  Now we allow the TextureClients to be destroyed, but when this happens at non-deterministic points the shmem sections in use can vary, which causes non-deterministic allocations of shmems, which we can't handle.  This PR avoids freeing shmem sections, and adds other diagnostics in case this isn't the actual problem.