### PR TITLE
Add diagnostics for different shmem section behavior

### DIFF
--- a/gfx/layers/ipc/ISurfaceAllocator.cpp
+++ b/gfx/layers/ipc/ISurfaceAllocator.cpp
@@ -233,6 +233,8 @@ void FixedSizeSmallShmemSectionAllocator::DeallocShmemSection(
 
 void FixedSizeSmallShmemSectionAllocator::ShrinkShmemSectionHeap() {
   if (!IPCOpen()) {
+    // https://github.com/RecordReplay/backend/issues/5113
+    recordreplay::RecordReplayAssert("FixedSizeSmallShmemSectionAllocator::ShrinkShmemSectionHeap IPC closed");
     mUsedShmems.clear();
     return;
   }

--- a/gfx/layers/ipc/ISurfaceAllocator.cpp
+++ b/gfx/layers/ipc/ISurfaceAllocator.cpp
@@ -104,13 +104,17 @@ bool FixedSizeSmallShmemSectionAllocator::AllocShmemSection(
   }
 
   // https://github.com/RecordReplay/backend/issues/5113
-  recordreplay::RecordReplayAssert("FixedSizeSmallShmemSectionAllocator::AllocShmemSection Start");
+  recordreplay::RecordReplayAssert("FixedSizeSmallShmemSectionAllocator::AllocShmemSection Start size=%u numUsedShmems=%zu",
+                                   aSize, mUsedShmems.size());
 
   uint32_t allocationSize = (aSize + sizeof(ShmemSectionHeapAllocation));
 
   for (size_t i = 0; i < mUsedShmems.size(); i++) {
     ShmemSectionHeapHeader* header =
         mUsedShmems[i].get<ShmemSectionHeapHeader>();
+    // https://github.com/RecordReplay/backend/issues/5113
+    recordreplay::RecordReplayAssert("FixedSizeSmallShmemSectionAllocator::AllocShmemSection Loop allocatedBlocks=%u",
+                                     (uint32_t)header->mAllocatedBlocks);
     if ((header->mAllocatedBlocks + 1) * allocationSize +
             sizeof(ShmemSectionHeapHeader) <
         sShmemPageSize) {
@@ -137,6 +141,9 @@ bool FixedSizeSmallShmemSectionAllocator::AllocShmemSection(
     mUsedShmems.push_back(tmp);
     aShmemSection->shmem() = tmp;
   }
+
+  // https://github.com/RecordReplay/backend/issues/5113
+  recordreplay::RecordReplayAssert("FixedSizeSmallShmemSectionAllocator::AllocShmemSection HaveShmem");
 
   MOZ_ASSERT(aShmemSection->shmem().IsWritable());
 
@@ -227,6 +234,12 @@ void FixedSizeSmallShmemSectionAllocator::DeallocShmemSection(
 void FixedSizeSmallShmemSectionAllocator::ShrinkShmemSectionHeap() {
   if (!IPCOpen()) {
     mUsedShmems.clear();
+    return;
+  }
+
+  // Refuse to free unused shmems when recording/replaying, for the same reason
+  // as in FreeShmemSection.
+  if (recordreplay::IsRecordingOrReplaying()) {
     return;
   }
 


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5113.  The mismatch we're seeing seems to indicate different contents for the different shmems used by the shmem section allocator.  I don't see how this can happen --- we have asserts around the places where I think we could be modifying the allocator shmems and their contents, though not all.  The class appears to main thread only and only modified by the content process, but I can't be 100% sure of this.  This PR adds more asserts around the remaining places the contents change, and ensures we don't remove shmems while shrinking the section heap, which I don't think is possible because we never free sections but it can't hurt to be sure.