### PR TITLE
Add recording assertions for promise resolution

### DIFF
--- a/js/src/builtin/Promise.cpp
+++ b/js/src/builtin/Promise.cpp
@@ -532,6 +532,9 @@ class PromiseDebugInfo : public NativeObject {
       }
     }
 
+    // https://github.com/RecordReplay/backend/issues/5145
+    mozilla::recordreplay::RecordReplayAssert("PromiseDebugInfo::setResolutionInfo Done");
+
     debugInfo->setFixedSlot(Slot_ResolutionSite, ObjectOrNullValue(stack));
     debugInfo->setFixedSlot(Slot_ResolutionTime,
                             DoubleValue(MillisecondsSinceStartup()));

--- a/xpcom/threads/TaskController.cpp
+++ b/xpcom/threads/TaskController.cpp
@@ -372,6 +372,9 @@ void TaskController::AddTask(already_AddRefed<Task>&& aTask) {
     task->mPriorityModifier = manager->mCurrentPriorityModifier;
   }
 
+  // https://github.com/RecordReplay/backend/issues/5145
+  mozilla::recordreplay::RecordReplayAssert("TaskController::AddTask Insert");
+
   task->mInsertionTime = TimeStamp::Now();
 
 #ifdef DEBUG


### PR DESCRIPTION
Diagnostics for https://github.com/RecordReplay/backend/issues/5145.  Since we're seeing a call stack mismatch here we need to convert it to a regular mismatch first.