### PR TITLE
Add diagnostic assert in timer thread

### DIFF
--- a/xpcom/threads/TimerThread.cpp
+++ b/xpcom/threads/TimerThread.cpp
@@ -490,6 +490,9 @@ TimerThread::Run() {
       }
     }
 
+    // https://github.com/RecordReplay/backend/issues/5146
+    recordreplay::RecordReplayAssert("TimerThread::Run Wait");
+
     mWaiting = true;
     mNotified = false;
     mMonitor.Wait(waitFor);


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5146.  As with https://github.com/RecordReplay/gecko-dev/pull/791 this is a call stack mismatch and we need asserts at the different sites to understand it better.  The other site has a recording assertion being added in https://github.com/RecordReplay/gecko-dev/pull/791.