### PR TITLE
Add Service Worker response headers to recording

### DIFF
--- a/devtools/server/actors/replay/network-helpers.jsm
+++ b/devtools/server/actors/replay/network-helpers.jsm
@@ -49,7 +49,7 @@ function getChannelRequestData(channel) {
   };
 }
 
-function getChannelResponseData(channel, fromCache) {
+function getChannelResponseData(channel, fromCache, fromServiceWorker) {
   const responseHeaders = [];
   channel.visitOriginalResponseHeaders({
     visitHeader: (name, value) => responseHeaders.push({ name, value }),
@@ -61,7 +61,8 @@ function getChannelResponseData(channel, fromCache) {
     responseStatus: channel.responseStatus,
     responseStatusText: channel.responseStatusText,
     responseFromCache: !!fromCache,
-    remoteDestination: fromCache ? null : {
+    responseFromServiceWorker: !!fromServiceWorker,
+    remoteDestination: (fromServiceWorker || fromCache) ? null : {
       address: channel.remoteAddress,
       port: channel.remotePort,
     },


### PR DESCRIPTION
This builds on all of the work done in https://github.com/RecordReplay/gecko-dev/commit/e8036bbb69c056c7cad44d91732f22c2695325e8 and just adds a single additional observer - `service-worker-synthesized-response`. Because requests that happen in service workers don't trigger the `http-on-examine-response` event. It also adds an additional flag, `fromServiceWorker`. I probably could have piggy-backed on the `fromCache` flag, but in the other FF code I've seen they differentiate between the two, and that makes me wonder if maybe we should just do that from the beginning as well (also it might be nice to show it in the net monitor in devtools someday). Here's a loom showing the work:

https://www.loom.com/share/df24ef86b9f64d3992c2745e8714ec00