### PR TITLE
Assert TaskController AddTask ordering.

### DIFF
--- a/xpcom/threads/TaskController.cpp
+++ b/xpcom/threads/TaskController.cpp
@@ -373,7 +373,11 @@ void TaskController::AddTask(already_AddRefed<Task>&& aTask) {
   }
 
   // https://github.com/RecordReplay/backend/issues/5145
-  mozilla::recordreplay::RecordReplayAssert("TaskController::AddTask Insert");
+  mozilla::recordreplay::RecordReplayAssert(
+    "TaskController::AddTask Insert mainThreadOnly=%d seqNo=%lld queueSize=%d",
+    task->IsMainThreadOnly(),
+    task->mSeqNo,
+    task->IsMainThreadOnly() ? mMainThreadTasks.size() : mThreadableTasks.size());
 
   task->mInsertionTime = TimeStamp::Now();
 


### PR DESCRIPTION
There's already an assertion within TaskController::AddTask, but it doesn't assert the order of tasks.

See issue https://github.com/RecordReplay/gecko-dev/issues/747