### PR TITLE
Refuse to enable wasm debug traps

### DIFF
--- a/js/src/wasm/WasmDebug.cpp
+++ b/js/src/wasm/WasmDebug.cpp
@@ -279,6 +279,12 @@ void DebugState::clearBreakpointsIn(JSFreeOp* fop, WasmInstanceObject* instance,
 }
 
 void DebugState::toggleDebugTrap(uint32_t offset, bool enabled) {
+  // Refuse to enable debug traps when recording/replaying. Sometimes these get
+  // enabled for unclear reasons, causing large performance degradations.
+  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+    enabled = false;
+  }
+
   MOZ_ASSERT(offset);
   uint8_t* trap = code_->segment(Tier::Debug).base() + offset;
   const Uint32Vector& farJumpOffsets =


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/4494, hopefully.  Without STR I'm just guessing at a fix here, but I don't think there's much risk in just not performing debug traps in wasm code when recording/replaying.  We're never interested in observing what wasm code is doing.