### PR TITLE
Disallow events in nsLoadGroup destructor

### DIFF
--- a/netwerk/base/nsLoadGroup.cpp
+++ b/netwerk/base/nsLoadGroup.cpp
@@ -91,6 +91,10 @@ nsLoadGroup::nsLoadGroup()
 }
 
 nsLoadGroup::~nsLoadGroup() {
+  // Destruction can occur at non-deterministic points even if events aren't
+  // currently disallowed.
+  recordreplay::AutoDisallowThreadEvents disallow;
+
   DebugOnly<nsresult> rv = Cancel(NS_BINDING_ABORTED);
   NS_ASSERTION(NS_SUCCEEDED(rv), "Cancel failed");
 


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/5249