### PR TITLE
Don't post timers for ghost window check at non-deterministic point

### DIFF
--- a/dom/base/nsWindowMemoryReporter.cpp
+++ b/dom/base/nsWindowMemoryReporter.cpp
@@ -751,6 +751,12 @@ void nsWindowMemoryReporter::AsyncCheckForGhostWindows() {
     return;
   }
 
+  // We don't support posting timers at non-deterministic points when
+  // recording/replaying, so skip the check in this case.
+  if (recordreplay::AreThreadEventsDisallowed()) {
+    return;
+  }
+
   // If more than kTimeBetweenChecks seconds have elapsed since the last check,
   // timerDelay is 0.  Otherwise, it is kTimeBetweenChecks, reduced by the time
   // since the last check.  Reducing the delay by the time since the last check

--- a/xpcom/threads/TimerThread.cpp
+++ b/xpcom/threads/TimerThread.cpp
@@ -490,9 +490,6 @@ TimerThread::Run() {
       }
     }
 
-    // https://github.com/RecordReplay/backend/issues/5146
-    recordreplay::RecordReplayAssert("TimerThread::Run Wait");
-
     mWaiting = true;
     mNotified = false;
     mMonitor.Wait(waitFor);


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/5146