### PR TITLE
Disallow events when releasing pipe output stream references

### DIFF
--- a/xpcom/io/nsPipe3.cpp
+++ b/xpcom/io/nsPipe3.cpp
@@ -1636,6 +1636,9 @@ nsPipeOutputStream::AddRef() {
 
 NS_IMETHODIMP_(MozExternalRefCountType)
 nsPipeOutputStream::Release() {
+  // References can be held by JS tearoffs and released at non-deterministic points.
+  recordreplay::AutoDisallowThreadEvents disallow;
+
   bool close;
   {
     ReentrantMonitorAutoEnterMaybeEventsDisallowed mon(mPipe->mReentrantMonitor);


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/4397