### PR TITLE
Disallow events while managing tear/offs instead of at all times when…

### DIFF
--- a/js/xpconnect/src/XPCWrappedNative.cpp
+++ b/js/xpconnect/src/XPCWrappedNative.cpp
@@ -940,6 +940,10 @@ nsresult XPCWrappedNative::InitTearOff(JSContext* cx,
                                        bool needJSObject) {
   // Determine if the object really does this interface...
 
+  // Because of non-deterministic GC behavior, tear/off behavior is non-deterministic
+  // as well and we shouldn't interact with the recording while creating tear/offs.
+  recordreplay::AutoDisallowThreadEvents disallow;
+
   const nsIID* iid = aInterface->GetIID();
   nsISupports* identity = GetIdentityObject();
 

--- a/xpcom/io/nsPipe3.cpp
+++ b/xpcom/io/nsPipe3.cpp
@@ -1636,9 +1636,6 @@ nsPipeOutputStream::AddRef() {
 
 NS_IMETHODIMP_(MozExternalRefCountType)
 nsPipeOutputStream::Release() {
-  // References can be held by JS tearoffs and released at non-deterministic points.
-  recordreplay::AutoDisallowThreadEvents disallow;
-
   bool close;
   {
     ReentrantMonitorAutoEnterMaybeEventsDisallowed mon(mPipe->mReentrantMonitor);


### PR DESCRIPTION
… releasing stream references

Fixes https://github.com/RecordReplay/backend/issues/5303