### PR TITLE
Suppress Firefox doorhangers for features/extension recommendations

### DIFF
--- a/browser/components/newtab/lib/CFRMessageProvider.jsm
+++ b/browser/components/newtab/lib/CFRMessageProvider.jsm
@@ -789,7 +789,9 @@ const CFR_MESSAGES = [
 
 const CFRMessageProvider = {
   getMessages() {
-    return Promise.resolve(CFR_MESSAGES.filter(msg => !msg.exclude));
+    // [Replay] - Suppress Firefox feature and extension recommendation door hangers
+    // return Promise.resolve(CFR_MESSAGES.filter(msg => !msg.exclude));
+    return Promise.resolve([]);
   },
 };
 this.CFRMessageProvider = CFRMessageProvider;


### PR DESCRIPTION
Fixes #805 

Tracked the message in question to https://github.com/RecordReplay/gecko-dev/blob/0f1ea71f6f63488de0e9822d1cd996dba21777fa/browser/locales/en-US/browser/newtab/asrouter.ftl#L110-L115 which is ultimately triggered by ASRouter.jsm which pulls it from CFRMessageProvider. I reviewed the messages listed in CFGMessageProvider and none seemed appropriate to show (they include things like the facebook container and a reddit extension along with messages like this DNS info).