### PR TITLE
Assert image-frame ordering in PresShell::UpdateImageLockingState.

### DIFF
--- a/layout/base/PresShell.cpp
+++ b/layout/base/PresShell.cpp
@@ -11081,6 +11081,8 @@ void PresShell::UpdateImageLockingState() {
     // quickly as possible when we get foregrounded to minimize flashing.
     for (const auto& key : mApproximatelyVisibleFrames) {
       if (nsImageFrame* imageFrame = do_QueryFrame(key)) {
+        recordreplay::RecordReplayAssert("PresShell::UpdateImageLockingState imageFrame=%u",
+          recordreplay::ThingIndex(imageFrame));
         imageFrame->MaybeDecodeForPredictedSize();
       }
     }


### PR DESCRIPTION
The loop calling `MaybeDecodeForPredictedSize` on imageFrame might be operating on different image-frames, leading to mismatches further down the line in `RasterImage::LookupFrame`.