### PR TITLE
Disallow events when releasing channel references

### DIFF
--- a/netwerk/protocol/http/HttpChannelChild.cpp
+++ b/netwerk/protocol/http/HttpChannelChild.cpp
@@ -167,6 +167,10 @@ void HttpChannelChild::ReleaseMainThreadOnlyReferences() {
 NS_IMPL_ADDREF(HttpChannelChild)
 
 NS_IMETHODIMP_(MozExternalRefCountType) HttpChannelChild::Release() {
+  // Reference counts can vary between recording/replaying and we don't want to
+  // interact with the recording.
+  recordreplay::AutoDisallowThreadEvents disallow;
+
   if (!NS_IsMainThread()) {
     nsrefcnt count = mRefCnt;
     nsresult rv = NS_DispatchToMainThread(NewNonOwningRunnableMethod(


### PR DESCRIPTION
This fixes the immediate problem (the call stack mismatch) in https://github.com/RecordReplay/backend/issues/5504