### PR TITLE
Allow IPDL message sends to vary when replaying

### DIFF
--- a/ipc/chromium/src/chrome/common/ipc_message.cc
+++ b/ipc/chromium/src/chrome/common/ipc_message.cc
@@ -54,6 +54,9 @@ Message::Message(int32_t routing_id, msgid_t type, uint32_t segment_capacity,
 #endif
   header()->footer_offset = -1;
   if (recordWriteLatency) {
+    // IPDL message sends are allowed to vary when recording/replaying, so don't
+    // interact with the recording when getting the creation time.
+    mozilla::recordreplay::AutoDisallowThreadEvents disallow;
     create_time_ = mozilla::TimeStamp::Now();
   }
 }

--- a/ipc/glue/MessageLink.cpp
+++ b/ipc/glue/MessageLink.cpp
@@ -101,50 +101,6 @@ PortLink::~PortLink() {
 void PortLink::SendMessage(UniquePtr<Message> aMessage) {
   mChan->mMonitor->AssertCurrentThreadOwns();
 
-  // Check that messages sent over IPC channels have consistent contents when
-  // recording vs. replaying.
-  recordreplay::RecordReplayAssert(
-    "PortLink::SendMessage channel=%u %d %d %u %s",
-    recordreplay::ThingIndex(mChan),
-    aMessage->type(),
-    aMessage->routing_id(),
-    aMessage->size(),
-    aMessage->name()
-  );
-
-  // When replaying message sizes must be consistent, or we'll crash when trying
-  // to send the messages because we'll get unexpected data from system calls
-  // which are being replayed. To improve robustness, force messages to be the
-  // same size when replaying by padding or truncating them.
-  size_t recordedSize = recordreplay::RecordReplayValue("PortLink::SendMessage", aMessage->size());
-  if (recordedSize != aMessage->size()) {
-    recordreplay::AutoPassThroughThreadEvents pt;
-    recordreplay::Diagnostic("PortLink::SendMessage resizing message from %zu to %zu",
-                             aMessage->size(), recordedSize);
-    if (recordedSize < aMessage->size()) {
-      PickleIterator iter(*aMessage);
-      // The total size includes the header which the iterator skips past,
-      // so correct for this difference.
-      MOZ_RELEASE_ASSERT(recordedSize >= aMessage->header_size());
-      if (!aMessage->IgnoreBytes(&iter, recordedSize - aMessage->header_size())) {
-        MOZ_CRASH("PortLink::SendMessage resize IgnoreBytes failed");
-      }
-      aMessage->Truncate(&iter);
-    } else {
-      size_t paddingSize = recordedSize - aMessage->size();
-      char* padding = new char[paddingSize];
-      memset(padding, 0, paddingSize);
-      if (!aMessage->WriteBytes(padding, paddingSize)) {
-        MOZ_CRASH("PortLink::SendMessage resize WriteBytes failed");
-      }
-      delete[] padding;
-    }
-    if (recordedSize != aMessage->size()) {
-      recordreplay::Diagnostic("PortLink::SendMessage resize failed, size is %zu", aMessage->size());
-      MOZ_CRASH("PortLink::SendMessage");
-    }
-  }
-
   if (aMessage->size() > IPC::Channel::kMaximumMessageSize) {
     CrashReporter::AnnotateCrashReport(
         CrashReporter::Annotation::IPCMessageName,

--- a/ipc/glue/ProtocolUtils.cpp
+++ b/ipc/glue/ProtocolUtils.cpp
@@ -518,11 +518,12 @@ void IProtocol::SetManagerAndRegister(IProtocol* aManager, int32_t aId) {
 bool IProtocol::ChannelSend(IPC::Message* aMsg) {
   UniquePtr<IPC::Message> msg(aMsg);
 
-  // We don't have a way to send IPC messages at non-deterministic points.
-  // For now, silently discard the messages.
-  if (recordreplay::AreThreadEventsDisallowed()) {
+  // IPC message sends are allowed to vary recording vs. replaying, so don't send
+  // them at all when replaying.
+  if (recordreplay::IsReplaying()) {
     return true;
   }
+  recordreplay::AutoDisallowThreadEvents disallow;
 
   if (CanSend()) {
     // NOTE: This send call failing can only occur during toplevel channel


### PR DESCRIPTION
Experimental PR for https://github.com/RecordReplay/backend/issues/5504.  This allows IPDL message sends to vary when recording vs. replaying, by disallowing events when messages are sent and not performing the sends at all when replaying.