### PR TITLE
Compute persistent IDs for objects constructed with 'new'

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -375,11 +375,10 @@ function registerSource(source) {
     } catch {}
   }
 
-  // The react devtools hook script is special cased as one that is available to clients,
-  // so that its frames and their arguments can be observed. Avoid using the default
-  // null url which getDebuggerSourceURL would normally use for this so that it is
-  // easier to distinguish from actual page JS.
-  if (source.url == "react-devtools-hook-script" && source.introductionType == "debugger eval") {
+  // replay-content:// protocol scripts are available to clients, so that their frames and
+  // arguments can be observed. Avoid using the default null url which getDebuggerSourceURL
+  // would normally use for this so that it is easier to distinguish from actual page JS.
+  if (source.url.startsWith("replay-content://") && source.introductionType == "debugger eval") {
     sourceURL = source.url;
   }
 

--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -375,6 +375,10 @@ function registerSource(source) {
     } catch {}
   }
 
+  if (source.url == "react-devtools-hook-script" && source.introductionType == "debugger eval") {
+    sourceURL = source.url;
+  }
+
   RecordReplayControl.recordReplayAssert(`RegisterSource #2 ${sourceURL}`);
 
   if (source.text !== "[wasm]") {

--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -1701,7 +1701,8 @@ function createProtocolObject(objectId, level) {
     preview = new ProtocolObjectPreview(obj, level).fill();
   }
 
-  return { objectId, className, preview };
+  const persistentId = RecordReplayControl.getPersistentId(obj.unsafeDereference());
+  return { objectId, className, preview, persistentId };
 }
 
 // Return whether an object should be ignored when generating previews.

--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -466,14 +466,9 @@ getWindow().docShell.chromeEventHandler.addEventListener(
   true
 );
 
-let gReactDevtoolsInitialized = false;
-
 gNewGlobalHooks.push(dbgWindow => {
-  if (!gReactDevtoolsInitialized) {
-    gReactDevtoolsInitialized = true;
-    initReactDevtools(dbgWindow, RecordReplayControl);
-    initReduxDevtools(dbgWindow, RecordReplayControl);
-  }
+  initReactDevtools(dbgWindow, RecordReplayControl);
+  initReduxDevtools(dbgWindow, RecordReplayControl);
 });
 
 // This logic is mostly copied from actors/style-sheet.js

--- a/devtools/server/actors/replay/react-devtools/contentScript.js
+++ b/devtools/server/actors/replay/react-devtools/contentScript.js
@@ -33,6 +33,10 @@ function initialize(dbgWindow, RecordReplayControl) {
     return RecordReplayControl.getPersistentId(obj);
   };
 
+  window.wrappedJSObject.__RECORD_REPLAY_CHECK_PERSISTENT_ID__ = obj => {
+    RecordReplayControl.checkPersistentId(obj);
+  };
+
   // The hook script is given a special URL so it won't be ignored and clients can inspect
   // state in its frames.
   const { installHook } = require("devtools/server/actors/replay/react-devtools/hook");

--- a/devtools/server/actors/replay/react-devtools/contentScript.js
+++ b/devtools/server/actors/replay/react-devtools/contentScript.js
@@ -29,8 +29,14 @@ function initialize(dbgWindow, RecordReplayControl) {
     RecordReplayControl.onAnnotation("react-devtools-hook", kind);
   };
 
+  window.wrappedJSObject.__RECORD_REPLAY_PERSISTENT_ID__ = obj => {
+    return RecordReplayControl.getPersistentId(obj);
+  };
+
+  // The hook script is given a special URL so it won't be ignored and clients can inspect
+  // state in its frames.
   const { installHook } = require("devtools/server/actors/replay/react-devtools/hook");
-  dbgWindow.executeInGlobal(`(${installHook}(window))`);
+  dbgWindow.executeInGlobal(`(${installHook}(window))`, { url: "react-devtools-hook-script" });
 
   const { reactDevtoolsBackend } = require("devtools/server/actors/replay/react-devtools/react_devtools_backend");
   dbgWindow.executeInGlobal(`(${reactDevtoolsBackend}(window))`);

--- a/devtools/server/actors/replay/react-devtools/contentScript.js
+++ b/devtools/server/actors/replay/react-devtools/contentScript.js
@@ -25,6 +25,10 @@ function initialize(dbgWindow, RecordReplayControl) {
       );
     };
 
+  window.wrappedJSObject.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__ = kind => {
+    RecordReplayControl.onAnnotation("react-devtools-hook", kind);
+  };
+
   const { installHook } = require("devtools/server/actors/replay/react-devtools/hook");
   dbgWindow.executeInGlobal(`(${installHook}(window))`);
 

--- a/devtools/server/actors/replay/react-devtools/contentScript.js
+++ b/devtools/server/actors/replay/react-devtools/contentScript.js
@@ -31,7 +31,7 @@ function initialize(dbgWindow, RecordReplayControl) {
 
   // The hook script uses the replay-content:// protocol so it won't be ignored
   // and clients can inspect state in its frames.
-  const reactDevtoolsHookScriptURL = "replay-content://react-devtools-hook-script";
+  const reactDevtoolsHookScriptURL = "replay-content:///react-devtools-hook-script";
 
   const { installHook } = require("devtools/server/actors/replay/react-devtools/hook");
   dbgWindow.executeInGlobal(`(${installHook}(window))`, { url: reactDevtoolsHookScriptURL });

--- a/devtools/server/actors/replay/react-devtools/contentScript.js
+++ b/devtools/server/actors/replay/react-devtools/contentScript.js
@@ -29,10 +29,9 @@ function initialize(dbgWindow, RecordReplayControl) {
     RecordReplayControl.onAnnotation("react-devtools-hook", kind);
   };
 
-  // The hook script is given a special URL so it won't be ignored and clients can
-  // inspect state in its frames. We test for this script in a few other places
-  // in gecko, so be careful when changing this.
-  const reactDevtoolsHookScriptURL = "react-devtools-hook-script";
+  // The hook script uses the replay-content:// protocol so it won't be ignored
+  // and clients can inspect state in its frames.
+  const reactDevtoolsHookScriptURL = "replay-content://react-devtools-hook-script";
 
   const { installHook } = require("devtools/server/actors/replay/react-devtools/hook");
   dbgWindow.executeInGlobal(`(${installHook}(window))`, { url: reactDevtoolsHookScriptURL });

--- a/devtools/server/actors/replay/react-devtools/contentScript.js
+++ b/devtools/server/actors/replay/react-devtools/contentScript.js
@@ -29,18 +29,13 @@ function initialize(dbgWindow, RecordReplayControl) {
     RecordReplayControl.onAnnotation("react-devtools-hook", kind);
   };
 
-  window.wrappedJSObject.__RECORD_REPLAY_PERSISTENT_ID__ = obj => {
-    return RecordReplayControl.getPersistentId(obj);
-  };
+  // The hook script is given a special URL so it won't be ignored and clients can
+  // inspect state in its frames. We test for this script in a few other places
+  // in gecko, so be careful when changing this.
+  const reactDevtoolsHookScriptURL = "react-devtools-hook-script";
 
-  window.wrappedJSObject.__RECORD_REPLAY_CHECK_PERSISTENT_ID__ = obj => {
-    RecordReplayControl.checkPersistentId(obj);
-  };
-
-  // The hook script is given a special URL so it won't be ignored and clients can inspect
-  // state in its frames.
   const { installHook } = require("devtools/server/actors/replay/react-devtools/hook");
-  dbgWindow.executeInGlobal(`(${installHook}(window))`, { url: "react-devtools-hook-script" });
+  dbgWindow.executeInGlobal(`(${installHook}(window))`, { url: reactDevtoolsHookScriptURL });
 
   const { reactDevtoolsBackend } = require("devtools/server/actors/replay/react-devtools/react_devtools_backend");
   dbgWindow.executeInGlobal(`(${reactDevtoolsBackend}(window))`);

--- a/devtools/server/actors/replay/react-devtools/hook.js
+++ b/devtools/server/actors/replay/react-devtools/hook.js
@@ -286,7 +286,7 @@ function installHook(target) {
   let uidCounter = 0;
 
   function inject(renderer) {
-    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("react-devtools-inject");
+    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("inject");
 
     const id = ++uidCounter;
     renderers.set(id, renderer);
@@ -398,7 +398,7 @@ function installHook(target) {
   }
 
   function onCommitFiberUnmount(rendererID, fiber) {
-    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("react-devtools-commit-fiber-unmount");
+    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("commit-fiber-unmount");
 
     const rendererInterface = rendererInterfaces.get(rendererID);
 
@@ -408,7 +408,7 @@ function installHook(target) {
   }
 
   function onCommitFiberRoot(rendererID, root, priorityLevel) {
-    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("react-devtools-commit-fiber-root");
+    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("commit-fiber-root");
 
     const mountedRoots = hook.getFiberRoots(rendererID);
     const current = root.current;
@@ -429,7 +429,7 @@ function installHook(target) {
   }
 
   function onPostCommitFiberRoot(rendererID, root) {
-    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("react-devtools-post-commit-fiber-root");
+    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("post-commit-fiber-root");
 
     const rendererInterface = rendererInterfaces.get(rendererID);
 

--- a/devtools/server/actors/replay/react-devtools/hook.js
+++ b/devtools/server/actors/replay/react-devtools/hook.js
@@ -286,6 +286,8 @@ function installHook(target) {
   let uidCounter = 0;
 
   function inject(renderer) {
+    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("react-devtools-inject");
+
     const id = ++uidCounter;
     renderers.set(id, renderer);
     const reactBuildType = hasDetectedBadDCE ? 'deadcode' : detectReactBuildType(renderer); // Patching the console enables DevTools to do a few useful things:
@@ -396,6 +398,8 @@ function installHook(target) {
   }
 
   function onCommitFiberUnmount(rendererID, fiber) {
+    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("react-devtools-commit-fiber-unmount");
+
     const rendererInterface = rendererInterfaces.get(rendererID);
 
     if (rendererInterface != null) {
@@ -404,6 +408,8 @@ function installHook(target) {
   }
 
   function onCommitFiberRoot(rendererID, root, priorityLevel) {
+    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("react-devtools-commit-fiber-root");
+
     const mountedRoots = hook.getFiberRoots(rendererID);
     const current = root.current;
     const isKnownRoot = mountedRoots.has(root);
@@ -423,6 +429,8 @@ function installHook(target) {
   }
 
   function onPostCommitFiberRoot(rendererID, root) {
+    window.__RECORD_REPLAY_REACT_DEVTOOLS_HOOK__("react-devtools-post-commit-fiber-root");
+
     const rendererInterface = rendererInterfaces.get(rendererID);
 
     if (rendererInterface != null) {

--- a/devtools/server/actors/replay/react-devtools/react_devtools_backend.js
+++ b/devtools/server/actors/replay/react-devtools/react_devtools_backend.js
@@ -7440,9 +7440,6 @@ function attach(hook, rendererID, renderer, global) {
       } else {
         const errorCount = mergeMapsAndGetCountHelper(fiber, fiberID, pendingFiberToErrorsMap, fiberIDToErrorsMap);
         const warningCount = mergeMapsAndGetCountHelper(fiber, fiberID, pendingFiberToWarningsMap, fiberIDToWarningsMap);
-
-        dump(`PUSH_OPERATION TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS ${fiberID} ${errorCount} ${warningCount}\n`);
-
         pushOperation(constants["q" /* TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS */]);
         pushOperation(fiberID);
         pushOperation(errorCount);
@@ -7486,8 +7483,6 @@ function attach(hook, rendererID, renderer, global) {
     // This enables roots to be mapped to renderers,
     // Which in turn enables fiber props, states, and hooks to be inspected.
 
-    dump(`FLUSH_PENDING_EVENTS RENDERER ${rendererID} ROOT ${currentRootID} STRING_LENGTH ${pendingStringTableLength} NUM_UNMOUNTS ${numUnmountIDs} PENDING_OPERATIONS ${pendingOperations}\n`);
-
     let i = 0;
     operations[i++] = rendererID;
     operations[i++] = currentRootID; // Now fill in the string table.
@@ -7506,8 +7501,6 @@ function attach(hook, rendererID, renderer, global) {
       }
 
       i += length;
-
-      dump(`STRING_OPERATION ${encodedString} POSITION ${i}\n`);
     });
 
     if (numUnmountIDs > 0) {
@@ -7569,9 +7562,6 @@ function attach(hook, rendererID, renderer, global) {
 
     const id = pendingStringTable.size + 1;
     const encodedString = Object(utils["m" /* utfEncodeString */])(string);
-
-    dump(`GET_STRING_ID ${string} ID ${id} ENCODED ${encodedString}\n`);
-
     pendingStringTable.set(string, {
       encodedString,
       id
@@ -7608,8 +7598,6 @@ function attach(hook, rendererID, renderer, global) {
     }
 
     if (isRoot) {
-      dump(`PUSH_OPERATION TREE_OPERATION_ADD ROOT ${id}\n`);
-
       pushOperation(constants["l" /* TREE_OPERATION_ADD */]);
       pushOperation(id);
       pushOperation(types["m" /* ElementTypeRoot */]);
@@ -7642,8 +7630,6 @@ function attach(hook, rendererID, renderer, global) {
       const displayNameStringID = getStringID(displayName); // This check is a guard to handle a React element that has been modified
       // in such a way as to bypass the default stringification of the "key" property.
 
-      dump(`PUSH_OPERATION TREE_OPERATION_ADD #2 ${id} PARENT ${parentID} OWNER ${ownerID}\n`);
-
       const keyString = key === null ? null : String(key);
       const keyStringID = getStringID(keyString);
       pushOperation(constants["l" /* TREE_OPERATION_ADD */]);
@@ -7655,8 +7641,6 @@ function attach(hook, rendererID, renderer, global) {
       pushOperation(keyStringID); // If this subtree has a new mode, let the frontend know.
 
       if ((fiber.mode & StrictModeBits) !== 0 && (parentFiber.mode & StrictModeBits) === 0) {
-        dump(`PUSH_OPERATION TREE_OPERATION_SET_SUBTREE_MODE ${id}\n`);
-
         pushOperation(constants["p" /* TREE_OPERATION_SET_SUBTREE_MODE */]);
         pushOperation(id);
         pushOperation(types["q" /* StrictMode */]);
@@ -7850,8 +7834,6 @@ function attach(hook, rendererID, renderer, global) {
       // because it's possible that one of its descendants did.
 
       if (alternate == null || treeBaseDuration !== alternate.treeBaseDuration) {
-        dump(`PUSH_OPERATION TREE_OPERATION_UPDATE_TREE_BASE_DURATION ${id}\n`);
-
         // Tree base duration updates are included in the operations typed array.
         // So we have to convert them from milliseconds to microseconds so we can send them as ints.
         const convertedTreeBaseDuration = Math.floor((treeBaseDuration || 0) * 1000);
@@ -7924,8 +7906,6 @@ function attach(hook, rendererID, renderer, global) {
       // No need to reorder.
       return;
     }
-
-    dump(`PUSH_OPERATION TREE_OPERATION_REORDER_CHILDREN ${getFiberIDThrows(fiber)} NUM_CHILDREN ${numChildren}\n`);
 
     pushOperation(constants["o" /* TREE_OPERATION_REORDER_CHILDREN */]);
     pushOperation(getFiberIDThrows(fiber));
@@ -15373,8 +15353,6 @@ function attach(hook, rendererID, renderer, global) {
     }
 
     if (isRoot) {
-      dump(`PUSH_OPERATION TREE_OPERATION_ADD #3 ${id}\n`);
-
       // TODO Is this right? For all versions?
       const hasOwnerMetadata = internalInstance._currentElement != null && internalInstance._currentElement._owner != null;
       pushOperation(constants["l" /* TREE_OPERATION_ADD */]);
@@ -15388,8 +15366,6 @@ function attach(hook, rendererID, renderer, global) {
 
       pushOperation(hasOwnerMetadata ? 1 : 0);
     } else {
-      dump(`PUSH_OPERATION TREE_OPERATION_ADD #4 ${id}\n`);
-
       const type = getElementType(internalInstance);
       const {
         displayName,
@@ -15409,8 +15385,6 @@ function attach(hook, rendererID, renderer, global) {
   }
 
   function recordReorder(internalInstance, id, nextChildren) {
-    dump(`PUSH_OPERATION TREE_OPERATION_REORDER_CHILDREN #2 ${id}\n`);
-
     pushOperation(constants["o" /* TREE_OPERATION_REORDER_CHILDREN */]);
     pushOperation(id);
     const nextChildIDs = nextChildren.map(getID);

--- a/devtools/server/actors/replay/react-devtools/react_devtools_backend.js
+++ b/devtools/server/actors/replay/react-devtools/react_devtools_backend.js
@@ -7440,6 +7440,9 @@ function attach(hook, rendererID, renderer, global) {
       } else {
         const errorCount = mergeMapsAndGetCountHelper(fiber, fiberID, pendingFiberToErrorsMap, fiberIDToErrorsMap);
         const warningCount = mergeMapsAndGetCountHelper(fiber, fiberID, pendingFiberToWarningsMap, fiberIDToWarningsMap);
+
+        dump(`PUSH_OPERATION TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS ${fiberID} ${errorCount} ${warningCount}\n`);
+
         pushOperation(constants["q" /* TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS */]);
         pushOperation(fiberID);
         pushOperation(errorCount);
@@ -7483,6 +7486,8 @@ function attach(hook, rendererID, renderer, global) {
     // This enables roots to be mapped to renderers,
     // Which in turn enables fiber props, states, and hooks to be inspected.
 
+    dump(`FLUSH_PENDING_EVENTS RENDERER ${rendererID} ROOT ${currentRootID} STRING_LENGTH ${pendingStringTableLength} NUM_UNMOUNTS ${numUnmountIDs} PENDING_OPERATIONS ${pendingOperations}\n`);
+
     let i = 0;
     operations[i++] = rendererID;
     operations[i++] = currentRootID; // Now fill in the string table.
@@ -7501,6 +7506,8 @@ function attach(hook, rendererID, renderer, global) {
       }
 
       i += length;
+
+      dump(`STRING_OPERATION ${encodedString} POSITION ${i}\n`);
     });
 
     if (numUnmountIDs > 0) {
@@ -7562,6 +7569,9 @@ function attach(hook, rendererID, renderer, global) {
 
     const id = pendingStringTable.size + 1;
     const encodedString = Object(utils["m" /* utfEncodeString */])(string);
+
+    dump(`GET_STRING_ID ${string} ID ${id} ENCODED ${encodedString}\n`);
+
     pendingStringTable.set(string, {
       encodedString,
       id
@@ -7598,6 +7608,8 @@ function attach(hook, rendererID, renderer, global) {
     }
 
     if (isRoot) {
+      dump(`PUSH_OPERATION TREE_OPERATION_ADD ROOT ${id}\n`);
+
       pushOperation(constants["l" /* TREE_OPERATION_ADD */]);
       pushOperation(id);
       pushOperation(types["m" /* ElementTypeRoot */]);
@@ -7630,6 +7642,8 @@ function attach(hook, rendererID, renderer, global) {
       const displayNameStringID = getStringID(displayName); // This check is a guard to handle a React element that has been modified
       // in such a way as to bypass the default stringification of the "key" property.
 
+      dump(`PUSH_OPERATION TREE_OPERATION_ADD #2 ${id} PARENT ${parentID} OWNER ${ownerID}\n`);
+
       const keyString = key === null ? null : String(key);
       const keyStringID = getStringID(keyString);
       pushOperation(constants["l" /* TREE_OPERATION_ADD */]);
@@ -7641,6 +7655,8 @@ function attach(hook, rendererID, renderer, global) {
       pushOperation(keyStringID); // If this subtree has a new mode, let the frontend know.
 
       if ((fiber.mode & StrictModeBits) !== 0 && (parentFiber.mode & StrictModeBits) === 0) {
+        dump(`PUSH_OPERATION TREE_OPERATION_SET_SUBTREE_MODE ${id}\n`);
+
         pushOperation(constants["p" /* TREE_OPERATION_SET_SUBTREE_MODE */]);
         pushOperation(id);
         pushOperation(types["q" /* StrictMode */]);
@@ -7834,6 +7850,8 @@ function attach(hook, rendererID, renderer, global) {
       // because it's possible that one of its descendants did.
 
       if (alternate == null || treeBaseDuration !== alternate.treeBaseDuration) {
+        dump(`PUSH_OPERATION TREE_OPERATION_UPDATE_TREE_BASE_DURATION ${id}\n`);
+
         // Tree base duration updates are included in the operations typed array.
         // So we have to convert them from milliseconds to microseconds so we can send them as ints.
         const convertedTreeBaseDuration = Math.floor((treeBaseDuration || 0) * 1000);
@@ -7906,6 +7924,8 @@ function attach(hook, rendererID, renderer, global) {
       // No need to reorder.
       return;
     }
+
+    dump(`PUSH_OPERATION TREE_OPERATION_REORDER_CHILDREN ${getFiberIDThrows(fiber)} NUM_CHILDREN ${numChildren}\n`);
 
     pushOperation(constants["o" /* TREE_OPERATION_REORDER_CHILDREN */]);
     pushOperation(getFiberIDThrows(fiber));
@@ -15353,6 +15373,8 @@ function attach(hook, rendererID, renderer, global) {
     }
 
     if (isRoot) {
+      dump(`PUSH_OPERATION TREE_OPERATION_ADD #3 ${id}\n`);
+
       // TODO Is this right? For all versions?
       const hasOwnerMetadata = internalInstance._currentElement != null && internalInstance._currentElement._owner != null;
       pushOperation(constants["l" /* TREE_OPERATION_ADD */]);
@@ -15366,6 +15388,8 @@ function attach(hook, rendererID, renderer, global) {
 
       pushOperation(hasOwnerMetadata ? 1 : 0);
     } else {
+      dump(`PUSH_OPERATION TREE_OPERATION_ADD #4 ${id}\n`);
+
       const type = getElementType(internalInstance);
       const {
         displayName,
@@ -15385,6 +15409,8 @@ function attach(hook, rendererID, renderer, global) {
   }
 
   function recordReorder(internalInstance, id, nextChildren) {
+    dump(`PUSH_OPERATION TREE_OPERATION_REORDER_CHILDREN #2 ${id}\n`);
+
     pushOperation(constants["o" /* TREE_OPERATION_REORDER_CHILDREN */]);
     pushOperation(id);
     const nextChildIDs = nextChildren.map(getID);

--- a/js/src/debugger/Script.cpp
+++ b/js/src/debugger/Script.cpp
@@ -1696,6 +1696,7 @@ static bool BytecodeIsEffectful(JSOp op) {
     case JSOp::ThrowMsg:
     case JSOp::ForceInterpreter:
     case JSOp::ExecutionProgress:
+    case JSOp::TrackConstructedThis:
       return false;
   }
 

--- a/js/src/frontend/BytecodeEmitter.h
+++ b/js/src/frontend/BytecodeEmitter.h
@@ -1051,7 +1051,8 @@ struct MOZ_STACK_CLASS BytecodeEmitter {
   }
 
   [[nodiscard]] bool emitTrackConstructedThis() {
-    if (shouldEmitInstrumentation() && mozilla::recordreplay::IsReplaying()) {
+    if (shouldEmitInstrumentation() &&
+        (mozilla::recordreplay::IsReplaying() || RecordReplayShouldTrackObjects())) {
       return emit1(JSOp::TrackConstructedThis);
     }
     return true;

--- a/js/src/frontend/BytecodeEmitter.h
+++ b/js/src/frontend/BytecodeEmitter.h
@@ -1050,6 +1050,13 @@ struct MOZ_STACK_CLASS BytecodeEmitter {
     return true;
   }
 
+  [[nodiscard]] bool emitTrackConstructedThis() {
+    if (shouldEmitInstrumentation() && mozilla::recordreplay::IsReplaying()) {
+      return emit1(JSOp::TrackConstructedThis);
+    }
+    return true;
+  }
+
   [[nodiscard]] bool emitInstrumentation(InstrumentationKind kind) {
     if (shouldEmitInstrumentation() &&
         mozilla::recordreplay::IsReplaying() &&

--- a/js/src/frontend/FunctionEmitter.cpp
+++ b/js/src/frontend/FunctionEmitter.cpp
@@ -410,6 +410,10 @@ bool FunctionScriptEmitter::prepareForParameters() {
     }
   }
 
+  if (!funbox_->isArrow() && !bce_->emitTrackConstructedThis()) {
+    return false;
+  }
+
 #ifdef DEBUG
   state_ = State::Parameters;
 #endif

--- a/js/src/jit/BaselineCodeGen.cpp
+++ b/js/src/jit/BaselineCodeGen.cpp
@@ -2229,6 +2229,7 @@ bool BaselineCodeGen<Handler>::emit_TrackConstructedThis() {
   }
 
   masm.bind(&notConstructing);
+  return true;
 }
 
 template <typename Handler>

--- a/js/src/jit/Lowering.cpp
+++ b/js/src/jit/Lowering.cpp
@@ -2896,6 +2896,13 @@ void LIRGenerator::visitExecutionProgress(MExecutionProgress* ins) {
   assignSafepoint(lir, ins);
 }
 
+void LIRGenerator::visitTrackObject(MTrackObject* ins) {
+  MOZ_ASSERT(ins->value()->type() == MIRType::Value);
+
+  LInstruction* lir = new (alloc()) LTrackObject(useBoxAtStart(ins->value()));
+  add(lir, ins);
+}
+
 void LIRGenerator::visitWasmInterruptCheck(MWasmInterruptCheck* ins) {
   auto* lir =
       new (alloc()) LWasmInterruptCheck(useRegisterAtStart(ins->tlsPtr()));

--- a/js/src/jit/MIR.h
+++ b/js/src/jit/MIR.h
@@ -5964,6 +5964,22 @@ class MExecutionProgress : public MNullaryInstruction {
   void* script() const { return script_; }
 };
 
+class MTrackObject : public MUnaryInstruction, public BoxInputsPolicy::Data {
+  bool checkFrameConstructing_;
+
+  MTrackObject(MDefinition* value, bool checkFrameConstructing)
+    : MUnaryInstruction(classOpcode, value), checkFrameConstructing_(checkFrameConstructing) {
+    setGuard();
+  }
+
+ public:
+  INSTRUCTION_HEADER(TrackObject)
+  TRIVIAL_NEW_WRAPPERS
+  NAMED_OPERANDS((0, value))
+
+  bool checkFrameConstructing() const { return checkFrameConstructing_; }
+};
+
 class MRecordReplayAssertValue : public MUnaryInstruction,
                                  public BoxInputsPolicy::Data {
   CompilerPropertyName name_;

--- a/js/src/jit/MIROps.yaml
+++ b/js/src/jit/MIROps.yaml
@@ -2234,6 +2234,9 @@
 - name: ExecutionProgress
   gen_boilerplate: false
 
+- name: TrackObject
+  gen_boilerplate: false
+
 - name: RecordReplayAssertValue
   gen_boilerplate: false
 

--- a/js/src/jit/VMFunctionList-inl.h
+++ b/js/src/jit/VMFunctionList-inl.h
@@ -159,6 +159,7 @@ namespace jit {
   _(InterpretResume, js::jit::InterpretResume)                                 \
   _(InterruptCheck, js::jit::InterruptCheck)                                   \
   _(RecordReplayProgressReached, js::RecordReplayProgressReached)              \
+  _(RecordReplayTrackObject, js::RecordReplayTrackObject)                      \
   _(InvokeFunction, js::jit::InvokeFunction)                                   \
   _(IonBinaryArithICUpdate, js::jit::IonBinaryArithIC::update)                 \
   _(IonBindNameICUpdate, js::jit::IonBindNameIC::update)                       \

--- a/js/src/jit/WarpBuilder.cpp
+++ b/js/src/jit/WarpBuilder.cpp
@@ -3120,6 +3120,27 @@ bool WarpBuilder::build_ExecutionProgress(BytecodeLocation loc) {
   return resumeAfter(progress, loc);
 }
 
+bool WarpBuilder::build_TrackConstructedThis(BytecodeLocation loc) {
+  if (!RecordReplayShouldTrackObjects()) {
+    return true;
+  }
+
+  bool checkFrameConstructing = false;
+  if (inlineCallInfo()) {
+    if (!inlineCallInfo()->constructing()) {
+      return true;
+    }
+  } else {
+    checkFrameConstructing = true;
+  }
+
+  MDefinition* thisv = current->getSlot(info().thisSlot());
+
+  MTrackObject* track = MTrackObject::New(alloc(), thisv, checkFrameConstructing);
+  current->add(track);
+  return true;
+}
+
 bool WarpBuilder::build_ThrowMsg(BytecodeLocation loc) {
   auto* ins = MThrowMsg::New(alloc(), loc.throwMsgKind());
   current->add(ins);

--- a/js/src/jit/WarpOracle.cpp
+++ b/js/src/jit/WarpOracle.cpp
@@ -706,6 +706,7 @@ AbortReasonOr<WarpScriptSnapshot*> WarpScriptOracle::createScriptSnapshot() {
       case JSOp::RetRval:
       case JSOp::RecordReplayAssert:
       case JSOp::ExecutionProgress:
+      case JSOp::TrackConstructedThis:
       case JSOp::InitialYield:
       case JSOp::Yield:
       case JSOp::ResumeKind:

--- a/js/src/jit/shared/LIR-shared.h
+++ b/js/src/jit/shared/LIR-shared.h
@@ -681,6 +681,20 @@ class LExecutionProgress : public LInstructionHelper<0, 0, 1> {
   const LDefinition* scratch() { return getTemp(0); }
 };
 
+class LTrackObject : public LInstructionHelper<0, BOX_PIECES, 0> {
+ public:
+  LIR_HEADER(TrackObject)
+
+  static const size_t ValueOperand = 0;
+
+  explicit LTrackObject(const LBoxAllocation& value)
+      : LInstructionHelper(classOpcode) {
+    setBoxOperand(ValueOperand, value);
+  }
+
+  MTrackObject* mir() const { return mir_->toTrackObject(); }
+};
+
 class LWasmInterruptCheck : public LInstructionHelper<0, 1, 0> {
  public:
   LIR_HEADER(WasmInterruptCheck)

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -1829,6 +1829,9 @@ class MOZ_RAII JS_PUBLIC_API AutoFilename {
   const char* get() const;
 };
 
+// Get any persistent ID being tracked for an object, or zero if there is none.
+extern JS_PUBLIC_API int RecordReplayGetTrackedObjectId(JSContext* cx, HandleObject obj);
+
 /**
  * Return the current filename, line number and column number of the most
  * currently running frame. Returns true if a scripted frame was found, false

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -1830,7 +1830,7 @@ class MOZ_RAII JS_PUBLIC_API AutoFilename {
 };
 
 // Get any persistent ID being tracked for an object, or zero if there is none.
-extern JS_PUBLIC_API int RecordReplayGetTrackedObjectId(JSContext* cx, HandleObject obj);
+extern JS_PUBLIC_API uint64_t RecordReplayGetTrackedObjectId(JSContext* cx, HandleObject obj);
 
 // Print a warning if IDs are being tracked but the specified object does not have one.
 extern JS_PUBLIC_API void RecordReplayCheckTrackedObject(JSContext* cx, HandleObject obj);

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -1832,6 +1832,9 @@ class MOZ_RAII JS_PUBLIC_API AutoFilename {
 // Get any persistent ID being tracked for an object, or zero if there is none.
 extern JS_PUBLIC_API int RecordReplayGetTrackedObjectId(JSContext* cx, HandleObject obj);
 
+// Print a warning if IDs are being tracked but the specified object does not have one.
+extern JS_PUBLIC_API void RecordReplayCheckTrackedObject(JSContext* cx, HandleObject obj);
+
 /**
  * Return the current filename, line number and column number of the most
  * currently running frame. Returns true if a scripted frame was found, false

--- a/js/src/vm/Initialization.cpp
+++ b/js/src/vm/Initialization.cpp
@@ -264,6 +264,12 @@ JS_PUBLIC_API const char* JS::detail::InitWithFailureDiagnostic(
     mozilla::recordreplay::SetExecutionProgressCallback(SetExecutionProgressTargetCallback);
     mozilla::recordreplay::SetTrackObjectsCallback(SetTrackObjectsCallback);
   }
+  if (mozilla::recordreplay::IsRecording()) {
+    mozilla::recordreplay::AutoPassThroughThreadEvents pt;
+    if (getenv("RECORDING_TRACK_OBJECTS")) {
+      SetTrackObjectsCallback(true);
+    }
+  }
 #endif
 
   libraryInitState = InitState::Running;

--- a/js/src/vm/Initialization.cpp
+++ b/js/src/vm/Initialization.cpp
@@ -262,6 +262,7 @@ JS_PUBLIC_API const char* JS::detail::InitWithFailureDiagnostic(
   }
   if (mozilla::recordreplay::IsReplaying()) {
     mozilla::recordreplay::SetExecutionProgressCallback(SetExecutionProgressTargetCallback);
+    mozilla::recordreplay::SetTrackObjectsCallback(SetTrackObjectsCallback);
   }
 #endif
 

--- a/js/src/vm/Interpreter.cpp
+++ b/js/src/vm/Interpreter.cpp
@@ -2187,6 +2187,13 @@ static MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER bool Interpret(JSContext* cx,
       AdvanceExecutionProgressCounter();
     END_CASE(ExecutionProgress)
 
+    CASE(TrackConstructedThis)
+      if (RecordReplayShouldTrackObjects() && REGS.fp()->isConstructing()) {
+        ReservedRooted<Value> val(&rootValue0, REGS.fp()->thisArgument());
+        RecordReplayTrackObject(cx, val);
+      }
+    END_CASE(TrackConstructedThis)
+
     CASE(Lineno)
     END_CASE(Lineno)
 

--- a/js/src/vm/Opcodes.h
+++ b/js/src/vm/Opcodes.h
@@ -3515,8 +3515,7 @@
      */ \
     MACRO(InstrumentationScriptId, instrumentation_script_id, NULL, 1, 0, 1, JOF_BYTE) \
     /*
-     * If record/replay progress is tracked for the script, add a record/replay
-     * assertion that the value is consistent between recording/replaying.
+     * Add a record/replay assertion that a value is consistent between recording/replaying.
      *
      *   Category: Other
      *   Operands: uint32_t nameIndex
@@ -3524,14 +3523,18 @@
      */ \
     MACRO(RecordReplayAssert, record_replay_assert, NULL, 5, 1, 0, JOF_ATOM) \
     /*
-     * If record/replay progress is tracked for the script, increment the
-     * execution progress counter.
+     * Increment the record/replay execution progress counter.
      *
      *   Category: Other
      *   Operands:
      *   Stack: =>
      */ \
     MACRO(ExecutionProgress, execution_progress, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * Ensure that an ID is tracked for the "this" object if the current frame
+     * is constructing.
+     */ \
+    MACRO(TrackConstructedThis, track_constructed_this, NULL, 1, 0, 0, JOF_BYTE) \
     /*
      * Break in the debugger, if one is attached. Otherwise this is a no-op.
      *
@@ -3555,7 +3558,6 @@
  * a power of two.  Use this macro to do so.
  */
 #define FOR_EACH_TRAILING_UNUSED_OPCODE(MACRO) \
-  MACRO(232)                                   \
   MACRO(233)                                   \
   MACRO(234)                                   \
   MACRO(235)                                   \

--- a/js/src/vm/Realm.cpp
+++ b/js/src/vm/Realm.cpp
@@ -570,11 +570,31 @@ void ObjectRealm::ensureTrackedObjectId(JSContext* cx, HandleObject obj) {
 }
 
 int ObjectRealm::getTrackedObjectId(JSObject* obj) {
+  if (!trackedObjectIdTable_) {
+    return 0;
+  }
+
   if (ObjectValueWeakMap::Ptr p = trackedObjectIdTable_->lookup(obj)) {
     return p->value().toInt32();
   }
 
   return 0;
+}
+
+void ObjectRealm::checkTrackedObject(JSObject* obj) {
+  if (!RecordReplayShouldTrackObjects()) {
+    return;
+  }
+
+  if (trackedObjectIdTable_) {
+    ObjectValueWeakMap::Ptr p = trackedObjectIdTable_->lookup(obj);
+    if (p) {
+      mozilla::recordreplay::PrintLog("Found tracked object ID %d for %p", p->value().toInt32(), obj);
+      return;
+    }
+  }
+
+  mozilla::recordreplay::PrintLog("Error: Unexpected missing tracked object ID for %p", obj);
 }
 
 void Realm::updateDebuggerObservesFlag(unsigned flag) {

--- a/js/src/vm/Realm.cpp
+++ b/js/src/vm/Realm.cpp
@@ -543,6 +543,10 @@ void Realm::setNewObjectMetadata(JSContext* cx, HandleObject obj) {
 static int gNextTrackedObjectId = 1;
 
 void ObjectRealm::ensureTrackedObjectId(JSContext* cx, HandleObject obj) {
+  if (mozilla::recordreplay::AreThreadEventsDisallowed()) {
+    return;
+  }
+
   AutoEnterOOMUnsafeRegion oomUnsafe;
 
   if (!trackedObjectIdTable_) {

--- a/js/src/vm/Realm.cpp
+++ b/js/src/vm/Realm.cpp
@@ -570,12 +570,10 @@ void ObjectRealm::ensureTrackedObjectId(JSContext* cx, HandleObject obj) {
 }
 
 uint64_t ObjectRealm::getTrackedObjectId(JSObject* obj) {
-  if (!trackedObjectIdTable_) {
-    return 0;
-  }
-
-  if (ObjectValueWeakMap::Ptr p = trackedObjectIdTable_->lookup(obj)) {
-    return (uint64_t) p->value().toDouble();
+  if (trackedObjectIdTable_) {
+    if (ObjectValueWeakMap::Ptr p = trackedObjectIdTable_->lookup(obj)) {
+      return (uint64_t) p->value().toDouble();
+    }
   }
 
   return 0;

--- a/js/src/vm/Realm.cpp
+++ b/js/src/vm/Realm.cpp
@@ -540,7 +540,7 @@ void Realm::setNewObjectMetadata(JSContext* cx, HandleObject obj) {
   }
 }
 
-static int gNextTrackedObjectId = 1;
+static uint64_t gNextTrackedObjectId = 1;
 
 void ObjectRealm::ensureTrackedObjectId(JSContext* cx, HandleObject obj) {
   if (mozilla::recordreplay::AreThreadEventsDisallowed()) {
@@ -563,19 +563,19 @@ void ObjectRealm::ensureTrackedObjectId(JSContext* cx, HandleObject obj) {
     return;
   }
 
-  Value targetVal(Int32Value(gNextTrackedObjectId++));
+  Value targetVal(DoubleValue(gNextTrackedObjectId++));
   if (!trackedObjectIdTable_->putNew(obj, targetVal)) {
     oomUnsafe.crash("createTrackedObjectId");
   }
 }
 
-int ObjectRealm::getTrackedObjectId(JSObject* obj) {
+uint64_t ObjectRealm::getTrackedObjectId(JSObject* obj) {
   if (!trackedObjectIdTable_) {
     return 0;
   }
 
   if (ObjectValueWeakMap::Ptr p = trackedObjectIdTable_->lookup(obj)) {
-    return p->value().toInt32();
+    return (uint64_t) p->value().toDouble();
   }
 
   return 0;

--- a/js/src/vm/Realm.cpp
+++ b/js/src/vm/Realm.cpp
@@ -589,7 +589,6 @@ void ObjectRealm::checkTrackedObject(JSObject* obj) {
   if (trackedObjectIdTable_) {
     ObjectValueWeakMap::Ptr p = trackedObjectIdTable_->lookup(obj);
     if (p) {
-      mozilla::recordreplay::PrintLog("Found tracked object ID %d for %p", p->value().toInt32(), obj);
       return;
     }
   }

--- a/js/src/vm/Realm.h
+++ b/js/src/vm/Realm.h
@@ -218,6 +218,7 @@ struct IteratorHashPolicy {
 };
 
 class DebugEnvironments;
+class ObjectValueWeakMap;
 class ObjectWeakMap;
 class WeakMapBase;
 
@@ -233,6 +234,10 @@ class ObjectRealm {
   // map because when loading scripts into a non-syntactic environment, we
   // need to use the same lexical environment to persist lexical bindings.
   js::UniquePtr<js::ObjectWeakMap> nonSyntacticLexicalEnvironments_;
+
+  // Keep track of record/replay persistent IDs for tracked objects. Keys are
+  // in this realm, values are numbers.
+  js::UniquePtr<js::ObjectValueWeakMap> trackedObjectIdTable_;
 
   ObjectRealm(const ObjectRealm&) = delete;
   void operator=(const ObjectRealm&) = delete;
@@ -283,6 +288,9 @@ class ObjectRealm {
                                             js::HandleObject thisv);
   js::NonSyntacticLexicalEnvironmentObject* getNonSyntacticLexicalEnvironment(
       JSObject* key) const;
+
+  void ensureTrackedObjectId(JSContext* cx, HandleObject obj);
+  int getTrackedObjectId(JSObject* obj);
 };
 
 }  // namespace js

--- a/js/src/vm/Realm.h
+++ b/js/src/vm/Realm.h
@@ -290,7 +290,7 @@ class ObjectRealm {
       JSObject* key) const;
 
   void ensureTrackedObjectId(JSContext* cx, HandleObject obj);
-  int getTrackedObjectId(JSObject* obj);
+  uint64_t getTrackedObjectId(JSObject* obj);
   void checkTrackedObject(JSObject* obj);
 };
 

--- a/js/src/vm/Realm.h
+++ b/js/src/vm/Realm.h
@@ -291,6 +291,7 @@ class ObjectRealm {
 
   void ensureTrackedObjectId(JSContext* cx, HandleObject obj);
   int getTrackedObjectId(JSObject* obj);
+  void checkTrackedObject(JSObject* obj);
 };
 
 }  // namespace js

--- a/js/src/vm/Runtime.cpp
+++ b/js/src/vm/Runtime.cpp
@@ -959,11 +959,16 @@ bool js::RecordReplayShouldTrackObjects() {
 }
 
 bool js::RecordReplayTrackObject(JSContext* cx, HandleValue val) {
+  if (val.isObject()) {
+    RootedObject obj(cx, &val.toObject());
+    ObjectRealm::get(obj).ensureTrackedObjectId(cx, obj);
+  }
   return true;
 }
 
 JS_PUBLIC_API int JS::RecordReplayGetTrackedObjectId(JSContext* cx, HandleObject obj) {
-  return 0;
+  JSObject* unwrapped = UncheckedUnwrap(obj);
+  return ObjectRealm::get(unwrapped).getTrackedObjectId(unwrapped);
 }
 
 bool js::RecordReplayAssertValue(JSContext* cx, HandlePropertyName name, HandleValue value) {

--- a/js/src/vm/Runtime.cpp
+++ b/js/src/vm/Runtime.cpp
@@ -971,6 +971,11 @@ JS_PUBLIC_API int JS::RecordReplayGetTrackedObjectId(JSContext* cx, HandleObject
   return ObjectRealm::get(unwrapped).getTrackedObjectId(unwrapped);
 }
 
+JS_PUBLIC_API void JS::RecordReplayCheckTrackedObject(JSContext* cx, HandleObject obj) {
+  JSObject* unwrapped = UncheckedUnwrap(obj);
+  ObjectRealm::get(unwrapped).checkTrackedObject(unwrapped);
+}
+
 bool js::RecordReplayAssertValue(JSContext* cx, HandlePropertyName name, HandleValue value) {
   if (!mozilla::recordreplay::IsRecordingOrReplaying()) {
     MOZ_RELEASE_ASSERT(gForceEmitRecordReplayAsserts);

--- a/js/src/vm/Runtime.cpp
+++ b/js/src/vm/Runtime.cpp
@@ -948,6 +948,7 @@ bool js::RecordReplayProgressReached(JSContext* cx) {
   return true;
 }
 
+// This is an int32_t so it can be accessed from jitcode.
 static int32_t gTrackObjects;
 
 void js::SetTrackObjectsCallback(bool aTrackObjects) {
@@ -985,7 +986,7 @@ bool js::RecordReplayTrackObject(JSContext* cx, HandleValue val) {
   return true;
 }
 
-JS_PUBLIC_API int JS::RecordReplayGetTrackedObjectId(JSContext* cx, HandleObject obj) {
+JS_PUBLIC_API uint64_t JS::RecordReplayGetTrackedObjectId(JSContext* cx, HandleObject obj) {
   JSObject* unwrapped = UncheckedUnwrap(obj);
   return ObjectRealm::get(unwrapped).getTrackedObjectId(unwrapped);
 }

--- a/js/src/vm/Runtime.cpp
+++ b/js/src/vm/Runtime.cpp
@@ -948,6 +948,24 @@ bool js::RecordReplayProgressReached(JSContext* cx) {
   return true;
 }
 
+static bool gTrackObjects;
+
+void js::SetTrackObjectsCallback(bool aTrackObjects) {
+  gTrackObjects = aTrackObjects;
+}
+
+bool js::RecordReplayShouldTrackObjects() {
+  return gTrackObjects;
+}
+
+bool js::RecordReplayTrackObject(JSContext* cx, HandleValue val) {
+  return true;
+}
+
+JS_PUBLIC_API int JS::RecordReplayGetTrackedObjectId(JSContext* cx, HandleObject obj) {
+  return 0;
+}
+
 bool js::RecordReplayAssertValue(JSContext* cx, HandlePropertyName name, HandleValue value) {
   if (!mozilla::recordreplay::IsRecordingOrReplaying()) {
     MOZ_RELEASE_ASSERT(gForceEmitRecordReplayAsserts);

--- a/js/src/vm/Runtime.h
+++ b/js/src/vm/Runtime.h
@@ -1215,6 +1215,9 @@ extern void SetTrackObjectsCallback(bool aTrackObjects);
 // Whether to track persistent IDs for new objects.
 extern bool RecordReplayShouldTrackObjects();
 
+// Get an address of the location which is non-zero when objects are being tracked.
+extern int32_t* RecordReplayAddressOfShouldTrackObjects();
+
 // Ensure an object has a persistent ID tracked over its lifetime.
 extern bool RecordReplayTrackObject(JSContext* cx, HandleValue val);
 

--- a/js/src/vm/Runtime.h
+++ b/js/src/vm/Runtime.h
@@ -1208,6 +1208,16 @@ extern void SetExecutionProgressTargetCallback(uint64_t aProgress);
 // Called when the target progress has been reached.
 extern bool RecordReplayProgressReached(JSContext* cx);
 
+// Callback used by the record/replay driver to indicate if persistent IDs should be
+// tracked for objects.
+extern void SetTrackObjectsCallback(bool aTrackObjects);
+
+// Whether to track persistent IDs for new objects.
+extern bool RecordReplayShouldTrackObjects();
+
+// Ensure an object has a persistent ID tracked over its lifetime.
+extern bool RecordReplayTrackObject(JSContext* cx, HandleValue val);
+
 extern bool ShouldEmitRecordReplayAssert(const char* aFilename,
                                          unsigned aLineno, unsigned aColumn);
 

--- a/mfbt/RecordReplay.cpp
+++ b/mfbt/RecordReplay.cpp
@@ -90,6 +90,7 @@ namespace recordreplay {
   Macro(AdvanceExecutionProgressCounter, (), ())                               \
   Macro(SetExecutionProgressCallback, (void (*aCallback)(uint64_t)), (aCallback)) \
   Macro(ExecutionProgressReached, (), ())                                      \
+  Macro(SetTrackObjectsCallback, (void (*aCallback)(bool)), (aCallback))       \
   Macro(InternalAssertScriptedCaller, (const char* aWhy), (aWhy))              \
   Macro(InternalNotifyActivity, (), ())                                        \
   Macro(AddProfilerEvent, (const char* aEvent, const char* aJSON), (aEvent, aJSON)) \

--- a/mfbt/RecordReplay.h
+++ b/mfbt/RecordReplay.h
@@ -249,6 +249,9 @@ MFBT_API void SetExecutionProgressCallback(void (*aCallback)(uint64_t));
 // Called when the last destination progress value which was set has been reached.
 MFBT_API void ExecutionProgressReached();
 
+// Set a callback the driver can use to track persistent IDs for created objects.
+MFBT_API void SetTrackObjectsCallback(void (*aCallback)(bool));
+
 // Get an identifier for the current execution point which can be used to warp
 // here later.
 MFBT_API ProgressCounter NewTimeWarpTarget();

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -855,6 +855,21 @@ static bool Method_GetPersistentId(JSContext* aCx, unsigned aArgc, Value* aVp) {
   return true;
 }
 
+static bool Method_CheckPersistentId(JSContext* aCx, unsigned aArgc, Value* aVp) {
+  CallArgs args = CallArgsFromVp(aArgc, aVp);
+
+  if (!args.get(0).isObject()) {
+    args.rval().setUndefined();
+    return true;
+  }
+
+  RootedObject obj(aCx, &args.get(0).toObject());
+  JS::RecordReplayCheckTrackedObject(aCx, obj);
+
+  args.rval().setUndefined();
+  return true;
+}
+
 static const JSFunctionSpec gRecordReplayMethods[] = {
   JS_FN("log", Method_Log, 1, 0),
   JS_FN("recordReplayAssert", Method_RecordReplayAssert, 1, 0),
@@ -880,6 +895,7 @@ static const JSFunctionSpec gRecordReplayMethods[] = {
   JS_FN("makeBookmark", Method_MakeBookmark, 0, 0),
   JS_FN("addPossibleBreakpoint", Method_AddPossibleBreakpoint, 4, 0),
   JS_FN("getPersistentId", Method_GetPersistentId, 1, 0),
+  JS_FN("checkPersistentId", Method_CheckPersistentId, 1, 0),
   JS_FS_END
 };
 

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -391,6 +391,7 @@ static bool IsInterestingSource(const char* aURL) {
     "moz-extension://",
     "resource://",
     "chrome://",
+    "react-devtools-hook-script",
   };
 
   for (const char* prefix : uninterestingPrefixes) {

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -832,6 +832,16 @@ static bool Method_AddPossibleBreakpoint(JSContext* aCx, unsigned aArgc, Value* 
 static bool Method_GetPersistentId(JSContext* aCx, unsigned aArgc, Value* aVp) {
   CallArgs args = CallArgsFromVp(aArgc, aVp);
 
+  // Persistent IDs can't be inspected unless we've diverged from the recording
+  // to inspect pause state. This method is accessible to page scripts so that
+  // persistent IDs can be read during record/replay evaluations, but if the page
+  // tries to read the persistent ID while running normally its behavior will
+  // diverge because we may or may not be tracking objects.
+  if (!HasDivergedFromRecording()) {
+    args.rval().setUndefined();
+    return true;
+  }
+
   if (!args.get(0).isObject()) {
     args.rval().setUndefined();
     return true;

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -828,6 +828,32 @@ static bool Method_AddPossibleBreakpoint(JSContext* aCx, unsigned aArgc, Value* 
   return true;
 }
 
+static bool Method_GetPersistentId(JSContext* aCx, unsigned aArgc, Value* aVp) {
+  CallArgs args = CallArgsFromVp(aArgc, aVp);
+
+  if (!args.get(0).isObject()) {
+    args.rval().setUndefined();
+    return true;
+  }
+
+  RootedObject obj(aCx, &args.get(0).toObject());
+
+  int persistentId = JS::RecordReplayGetTrackedObjectId(aCx, obj);
+  if (persistentId) {
+    char buf[50];
+    snprintf(buf, sizeof(buf), "obj%d", persistentId);
+    RootedString rv(aCx, JS_NewStringCopyZ(aCx, buf));
+    if (!rv) {
+      return false;
+    }
+    args.rval().setString(rv);
+    return true;
+  }
+
+  args.rval().setUndefined();
+  return true;
+}
+
 static const JSFunctionSpec gRecordReplayMethods[] = {
   JS_FN("log", Method_Log, 1, 0),
   JS_FN("recordReplayAssert", Method_RecordReplayAssert, 1, 0),
@@ -852,6 +878,7 @@ static const JSFunctionSpec gRecordReplayMethods[] = {
   JS_FN("recordingOperations", Method_RecordingOperations, 0, 0),
   JS_FN("makeBookmark", Method_MakeBookmark, 0, 0),
   JS_FN("addPossibleBreakpoint", Method_AddPossibleBreakpoint, 4, 0),
+  JS_FN("getPersistentId", Method_GetPersistentId, 1, 0),
   JS_FS_END
 };
 

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -391,7 +391,7 @@ static bool IsInterestingSource(const char* aURL) {
     "moz-extension://",
     "resource://",
     "chrome://",
-    "react-devtools-hook-script",
+    "replay-content://",
   };
 
   for (const char* prefix : uninterestingPrefixes) {
@@ -849,10 +849,10 @@ static bool Method_GetPersistentId(JSContext* aCx, unsigned aArgc, Value* aVp) {
 
   RootedObject obj(aCx, &args.get(0).toObject());
 
-  int persistentId = JS::RecordReplayGetTrackedObjectId(aCx, obj);
+  uint64_t persistentId = JS::RecordReplayGetTrackedObjectId(aCx, obj);
   if (persistentId) {
     char buf[50];
-    snprintf(buf, sizeof(buf), "obj%d", persistentId);
+    snprintf(buf, sizeof(buf), "obj%llu", persistentId);
     RootedString rv(aCx, JS_NewStringCopyZ(aCx, buf));
     if (!rv) {
       return false;

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -96,6 +96,7 @@ static void (*gFinishRecording)();
 static uint64_t* (*gProgressCounter)();
 static void (*gSetProgressCallback)(void (*aCallback)(uint64_t));
 static void (*gProgressReached)();
+static void (*gSetTrackObjectsCallback)(void (*aCallback)(bool));
 static void (*gBeginPassThroughEvents)();
 static void (*gEndPassThroughEvents)();
 static bool (*gAreEventsPassedThrough)();
@@ -397,6 +398,7 @@ MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
   LoadSymbol("RecordReplayProgressCounter", gProgressCounter);
   LoadSymbol("RecordReplaySetProgressCallback", gSetProgressCallback, /* aOptional */ true);
   LoadSymbol("RecordReplayProgressReached", gProgressReached, /* aOptional */ true);
+  LoadSymbol("RecordReplaySetTrackObjectsCallback", gSetTrackObjectsCallback);
   LoadSymbol("RecordReplayBeginPassThroughEvents", gBeginPassThroughEvents);
   LoadSymbol("RecordReplayEndPassThroughEvents", gEndPassThroughEvents);
   LoadSymbol("RecordReplayAreEventsPassedThrough", gAreEventsPassedThrough);
@@ -608,6 +610,10 @@ MOZ_EXPORT void RecordReplayInterface_SetExecutionProgressCallback(void (*aCallb
 
 MOZ_EXPORT void RecordReplayInterface_ExecutionProgressReached() {
   gProgressReached();
+}
+
+MOZ_EXPORT void RecordReplayInterface_SetTrackObjectsCallback(void (*aCallback)(bool)) {
+  gSetTrackObjectsCallback(aCallback);
 }
 
 MOZ_EXPORT void RecordReplayInterface_InternalBeginPassThroughThreadEvents() {


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5144, goes with https://github.com/RecordReplay/backend/pull/5312.  This adds APIs and opcode implementations for keeping track of persistent IDs for objects constructed using "new Foo()" for scripted functions.  The actual mapping between objects and IDs still remains to be done.