### PR TITLE
Add devtools backends to all top http(s) globals (#716)

### DIFF
--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -466,11 +466,9 @@ getWindow().docShell.chromeEventHandler.addEventListener(
   true
 );
 
-let gReactDevtoolsInitialized = false;
-
 gNewGlobalHooks.push(dbgWindow => {
-  if (!gReactDevtoolsInitialized) {
-    gReactDevtoolsInitialized = true;
+  const window = dbgWindow.unsafeDereference();
+  if (window.parent === window && window.location.href.match(/https?:\/\//)) {
     initReactDevtools(dbgWindow, RecordReplayControl);
     initReduxDevtools(dbgWindow, RecordReplayControl);
   }


### PR DESCRIPTION
Fixes #716
Currently we're only adding devtools backends to the first global (i.e. window) object, with this PR we add them to all "top" globals with an http(s) URL.
