### PR TITLE
Minor fix running nondeterministic events in nsThreadPool::Run.

### DIFF
--- a/xpcom/threads/nsThreadPool.cpp
+++ b/xpcom/threads/nsThreadPool.cpp
@@ -257,8 +257,11 @@ nsThreadPool::Run() {
       recordreplay::AutoDisallowThreadEvents disallow;
       MutexAutoLock lock(mMutexNonDeterministic);
       TimeDuration delay;
-      nsCOMPtr<nsIRunnable> event = mEventsNonDeterministic.GetEvent(lock, &delay);
-      if (event) {
+      for (;;) {
+        nsCOMPtr<nsIRunnable> event = mEventsNonDeterministic.GetEvent(lock, &delay);
+        if (!event) {
+          break;
+        }
         event->Run();
       }
     }


### PR DESCRIPTION
Noticed this while filing asserts a while back.  Comment indicates that "any" nondeterministic events are run, but the code as written will only run a single one each loop iteration.