### PR TITLE
Forward replay: url onto error page

### DIFF
--- a/toolkit/mozapps/handling/ContentDispatchChooser.jsm
+++ b/toolkit/mozapps/handling/ContentDispatchChooser.jsm
@@ -322,8 +322,9 @@ const replaySchemeMap = {
       pingTelemetry("replay:record", "record", { url: target, newtab });
       toggleRecording(browser.ownerDocument.defaultView.gBrowser.selectedBrowser);
     }).catch((e) => {
+      const message = encodeURIComponent('Failed to launch recorder: ' + e.message);
       pingTelemetry("replay:record", "error", { url: target, newtab, message: e.message });
-      tabbrowser.loadURI(`https://app.replay.io/browser/error?message=Failed to launch recorder: (${e.message})&url=${encodeURIComponent(url.asciiSpec)}`, {
+      tabbrowser.loadURI(`https://app.replay.io/browser/error?message=${message}&url=${encodeURIComponent(url.spec)}`, {
         triggeringPrincipal: principal
       });
     });

--- a/toolkit/mozapps/handling/ContentDispatchChooser.jsm
+++ b/toolkit/mozapps/handling/ContentDispatchChooser.jsm
@@ -323,7 +323,7 @@ const replaySchemeMap = {
       toggleRecording(browser.ownerDocument.defaultView.gBrowser.selectedBrowser);
     }).catch((e) => {
       pingTelemetry("replay:record", "error", { url: target, newtab, message: e.message });
-      tabbrowser.loadURI(`https://app.replay.io/browser/error?message=Failed to launch recorder: (${e.message})`, {
+      tabbrowser.loadURI(`https://app.replay.io/browser/error?message=Failed to launch recorder: (${e.message})&url=${encodeURIComponent(url.asciiSpec)}`, {
         triggeringPrincipal: principal
       });
     });


### PR DESCRIPTION
Pass the requested url (e.g. `replay:record?url=https://static.replay.io/demo`) onto the error page in devtools so we can offer a "try again" button there