### PR TITLE
Support building branches with slash in branch name

### DIFF
--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -5,7 +5,7 @@ const {
   newTask,
 } = require("../utils");
 
-const branchName = getBranchName(process.env.GITHUB_REF);
+const branchName = process.env.GITHUB_REF_NAME
 console.log("BranchName", branchName);
 
 const replayRevision = getLatestReplayRevision();
@@ -88,13 +88,4 @@ function platformTasks(platform) {
   }
 
   return tasks;
-}
-
-function getBranchName(refName) {
-  // Strip everything after the last "/" from the ref to get the branch name.
-  const index = refName.lastIndexOf("/");
-  if (index == -1) {
-    return refName;
-  }
-  return refName.substring(index + 1);
 }


### PR DESCRIPTION
## Issue

If your branch has a slash in it, the build script will strip everything before and including the slash and pass that along to the build machine which fails because it can't find that invalid branch name

## Resolution

Use `GITHUB_REF_NAME` instead of `GITHUB_REF` to avoid parsing out the branch name.

## Test Results

https://github.com/replayio/gecko-dev/runs/6863976093?check_suite_focus=true#step:4:11

<img width="960" alt="image" src="https://user-images.githubusercontent.com/788456/173385189-0d65d4a2-0d3d-498c-a059-2d2cdd9f3874.png">
