### PR TITLE
Use fault callback API to handle wasm traps

### DIFF
--- a/js/src/wasm/WasmSignalHandlers.cpp
+++ b/js/src/wasm/WasmSignalHandlers.cpp
@@ -909,11 +909,6 @@ static bool EnsureLazyProcessSignalHandlers() {
   lazyInstallState->tried = true;
   MOZ_RELEASE_ASSERT(lazyInstallState->success == false);
 
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
-    lazyInstallState->success = true;
-    return true;
-  }
-
 #ifdef XP_DARWIN
   // Create the port that all JSContext threads will redirect their traps to.
   kern_return_t kret;
@@ -956,6 +951,11 @@ bool wasm::EnsureFullSignalHandlers(JSContext* cx) {
     if (!eagerInstallState->success) {
       return false;
     }
+  }
+
+  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+    cx->wasm().haveSignalHandlers = true;
+    return true;
   }
 
   if (!EnsureLazyProcessSignalHandlers()) {

--- a/js/src/wasm/WasmSignalHandlers.cpp
+++ b/js/src/wasm/WasmSignalHandlers.cpp
@@ -505,6 +505,51 @@ struct AutoHandlingTrap {
   return true;
 }
 
+static bool RecordReplayFaultCallback(void** prip, void* rbp, void* rsp) {
+  if (sAlreadyHandlingTrap.get()) {
+    return false;
+  }
+
+  AutoHandlingTrap aht;
+
+  void* pc = *prip;
+  const CodeSegment* codeSegment = LookupCodeSegment(pc);
+  if (!codeSegment || !codeSegment->isModule()) {
+    return false;
+  }
+
+  const ModuleSegment& segment = *codeSegment->asModule();
+
+  Trap trap;
+  BytecodeOffset bytecode;
+  if (!segment.code().lookupTrap(pc, &trap, &bytecode)) {
+    return false;
+  }
+
+  auto* frame = reinterpret_cast<Frame*>(rbp);
+  Instance* instance = GetNearestEffectiveTls(frame)->instance;
+  MOZ_RELEASE_ASSERT(&instance->code() == &segment.code() ||
+                     trap == Trap::IndirectCallBadSig);
+
+  JSContext* cx =
+      instance->realm()->runtimeFromAnyThread()->mainContextFromAnyThread();
+
+  JS::ProfilingFrameIterator::RegisterState registerState;
+  registerState.fp = rbp;
+  registerState.pc = pc;
+  registerState.sp = rsp;
+  registerState.lr = (void*)UINTPTR_MAX;
+
+  // JitActivation::startWasmTrap() stores enough register state from the
+  // point of the trap to allow stack unwinding or resumption, both of which
+  // will call finishWasmTrap().
+  jit::JitActivation* activation = cx->activation()->asJit();
+  activation->startWasmTrap(trap, bytecode.offset(), registerState);
+
+  *prip = segment.trapCode();
+  return true;
+}
+
 // =============================================================================
 // The following platform-specific handlers funnel all signals/exceptions into
 // the shared HandleTrap() above.
@@ -785,6 +830,12 @@ void wasm::EnsureEagerProcessSignalHandlers() {
 
   sAlreadyHandlingTrap.infallibleInit();
 
+  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+    mozilla::recordreplay::SetFaultCallback(RecordReplayFaultCallback);
+    eagerInstallState->success = true;
+    return;
+  }
+
   // Install whatever exception/signal handler is appropriate for the OS.
 #if defined(XP_WIN)
 
@@ -857,6 +908,11 @@ static bool EnsureLazyProcessSignalHandlers() {
 
   lazyInstallState->tried = true;
   MOZ_RELEASE_ASSERT(lazyInstallState->success == false);
+
+  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+    lazyInstallState->success = true;
+    return true;
+  }
 
 #ifdef XP_DARWIN
   // Create the port that all JSContext threads will redirect their traps to.

--- a/mfbt/RecordReplay.cpp
+++ b/mfbt/RecordReplay.cpp
@@ -95,7 +95,9 @@ namespace recordreplay {
   Macro(InternalNotifyActivity, (), ())                                        \
   Macro(AddProfilerEvent, (const char* aEvent, const char* aJSON), (aEvent, aJSON)) \
   Macro(LabelExecutableCode, (const void* aCode, size_t aSize, const char* aKind), \
-        (aCode, aSize, aKind))
+        (aCode, aSize, aKind))                                                 \
+  Macro(SetFaultCallback, (FaultCallback aCallback), (aCallback))
+
 // clang-format on
 
 #define DECLARE_SYMBOL(aName, aReturnType, aFormals, _) \

--- a/mfbt/RecordReplay.h
+++ b/mfbt/RecordReplay.h
@@ -330,6 +330,10 @@ MFBT_API void AddProfilerEvent(const char* aEvent, const char* aJSON);
 // Label executable code with a kind. Used while profiling.
 MFBT_API void LabelExecutableCode(const void* aCode, size_t aSize, const char* aKind);
 
+// Set a callback to invoke whenever a fault is encountered.
+typedef bool (*FaultCallback)(void** aPRIP, void* aRBP, void* aRSP);
+MFBT_API void SetFaultCallback(FaultCallback aCallback);
+
 ///////////////////////////////////////////////////////////////////////////////
 // Gecko interface
 ///////////////////////////////////////////////////////////////////////////////

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -80,6 +80,7 @@ static void (*gSetApiKey)(const char* apiKey);
 static void (*gProfileExecution)(const char* path);
 static void (*gAddProfilerEvent)(const char* event, const char* json);
 static void (*gLabelExecutableCode)(const void* aCode, size_t aSize, const char* aKind);
+static void (*gSetFaultCallback)(FaultCallback aCallback);
 static void (*gRecordCommandLineArguments)(int*, char***);
 static uintptr_t (*gRecordReplayValue)(const char* why, uintptr_t value);
 static void (*gRecordReplayBytes)(const char* why, void* buf, size_t size);
@@ -381,6 +382,7 @@ MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
   LoadSymbol("RecordReplayProfileExecution", gProfileExecution);
   LoadSymbol("RecordReplayAddProfilerEvent", gAddProfilerEvent);
   LoadSymbol("RecordReplayLabelExecutableCode", gLabelExecutableCode);
+  LoadSymbol("RecordReplaySetFaultCallback", gSetFaultCallback);
   LoadSymbol("RecordReplayRecordCommandLineArguments",
              gRecordCommandLineArguments);
   LoadSymbol("RecordReplayValue", gRecordReplayValue);
@@ -740,6 +742,12 @@ MOZ_EXPORT void RecordReplayInterface_AddProfilerEvent(const char* aEvent, const
 MOZ_EXPORT void RecordReplayInterface_LabelExecutableCode(const void* aCode, size_t aSize, const char* aKind) {
   if (gIsRecordingOrReplaying || gIsProfiling) {
     gLabelExecutableCode(aCode, aSize, aKind);
+  }
+}
+
+MOZ_EXPORT void RecordReplayInterface_SetFaultCallback(FaultCallback aCallback) {
+  if (gIsRecordingOrReplaying) {
+    gSetFaultCallback(aCallback);
   }
 }
 


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-374/linux-crash-wasminstancecallexport