### PR TITLE
Make IsRecordingOrReplaying calls controllable

### DIFF
--- a/accessible/generic/LocalAccessible.h
+++ b/accessible/generic/LocalAccessible.h
@@ -178,14 +178,14 @@ class LocalAccessible : public nsISupports, public Accessible {
     // When recording or replaying, use an ID which will be consistent when
     // recording/replaying (pointer values are not consistent), so that IPC
     // messages from the parent process can be handled when replaying.
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("UniqueID")) {
       return reinterpret_cast<void*>(recordreplay::ThingIndex(this));
     }
     return static_cast<void*>(this);
   }
 
   static LocalAccessible* FromUniqueID(uint64_t aId) {
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("FromUniqueID")) {
       return reinterpret_cast<LocalAccessible*>(recordreplay::IndexThing(aId));
     }
     return reinterpret_cast<LocalAccessible*>(aId);

--- a/docshell/base/BrowsingContext.cpp
+++ b/docshell/base/BrowsingContext.cpp
@@ -2963,7 +2963,7 @@ mozilla::dom::TouchEventsOverride BrowsingContext::TouchEventsOverride() const {
 // We map `watchedByDevTools` WebIDL attribute to `watchedByDevToolsInternal`
 // BC field. And we map it to the top level BrowsingContext.
 bool BrowsingContext::WatchedByDevTools() {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("WatchedByDevTools")) {
     return true;
   }
   return Top()->GetWatchedByDevToolsInternal();

--- a/dom/base/CCGCScheduler.cpp
+++ b/dom/base/CCGCScheduler.cpp
@@ -207,7 +207,7 @@ void CCGCScheduler::PokeShrinkingGC() {
 
 void CCGCScheduler::PokeFullGC() {
   // GC timers aren't supported when recording/replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("PokeFullGC")) {
     return;
   }
 
@@ -266,7 +266,7 @@ void CCGCScheduler::EnsureGCRunner(uint32_t aDelay) {
   }
 
   // Incremental GC is disabled when recording/replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("EnsureGCRunner")) {
     return;
   }
 
@@ -322,7 +322,7 @@ void CCGCScheduler::EnsureCCRunner(TimeDuration aDelay, TimeDuration aBudget) {
   MOZ_ASSERT(!mDidShutdown);
 
   // Incremental CC is disabled when recording/replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("EnsureCCRunner")) {
     return;
   }
 

--- a/dom/base/ChromeUtils.cpp
+++ b/dom/base/ChromeUtils.cpp
@@ -270,7 +270,7 @@ void ChromeUtils::AddProfilerMarker(
 
 /* static */
 bool ChromeUtils::IsRecordingOrReplaying(GlobalObject& aGlobal) {
-  return recordreplay::IsRecordingOrReplaying();
+  return recordreplay::IsRecordingOrReplaying("ChromeUtils");
 }
 
 /* static */

--- a/dom/base/nsJSEnvironment.cpp
+++ b/dom/base/nsJSEnvironment.cpp
@@ -1508,7 +1508,7 @@ void nsJSContext::EndCycleCollectionCallback(CycleCollectorResults& aResults) {
 bool CCGCScheduler::CCRunnerFired(TimeStamp aDeadline) {
   bool didDoWork = false;
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("CCRunnerFired")) {
     return false;
   }
 

--- a/dom/canvas/CanvasRenderingContextHelper.cpp
+++ b/dom/canvas/CanvasRenderingContextHelper.cpp
@@ -167,7 +167,7 @@ already_AddRefed<nsISupports> CanvasRenderingContextHelper::GetContext(
   if (!CanvasUtils::GetCanvasContextType(aContextId, &contextType))
     return nullptr;
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("CanvasRenderingContextHelper::GetContext")) {
     // GL/GPU contexts are not supported when recording/replaying.
     if (contextType == CanvasContextType::WebGL1 ||
         contextType == CanvasContextType::WebGL2 ||

--- a/dom/canvas/WebGLContext.cpp
+++ b/dom/canvas/WebGLContext.cpp
@@ -249,7 +249,7 @@ bool WebGLContext::CreateAndInitGL(
   const FuncScope funcScope(*this, "<Create>");
 
   // WebGL can't be used when recording/replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("CreateAndInitGL")) {
     recordreplay::ReportUnsupportedFeature("WebGL", 58);
     FailureReason reason;
     reason.info =

--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -1273,7 +1273,7 @@ HTMLMediaElement::MediaLoadListener::OnStartRequest(nsIRequest* aRequest) {
 
   // Media element playback is not currently supported when recording or
   // replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("MediaLoadListener::OnStartRequest")) {
     recordreplay::ReportUnsupportedFeature("MediaPlayback", 54);
     mElement->ReportLoadError("Media elements not available when recording");
     return NS_ERROR_NOT_AVAILABLE;

--- a/dom/ipc/BrowserChild.cpp
+++ b/dom/ipc/BrowserChild.cpp
@@ -1264,7 +1264,7 @@ mozilla::ipc::IPCResult BrowserChild::RecvUpdateDimensions(
     const DimensionInfo& aDimensionInfo) {
   // When recording/replaying we need to make sure the dimensions are up to
   // date on the compositor used in this process.
-  if (mLayersConnected.isNothing() && !recordreplay::IsRecordingOrReplaying()) {
+  if (mLayersConnected.isNothing() && !recordreplay::IsRecordingOrReplaying("RecvUpdateDimensions")) {
     return IPC_OK();
   }
 
@@ -1637,7 +1637,7 @@ void BrowserChild::FlushAllCoalescedMouseData() {
 mozilla::ipc::IPCResult BrowserChild::RecvRealMouseMoveEvent(
     const WidgetMouseEvent& aEvent, const ScrollableLayerGuid& aGuid,
     const uint64_t& aInputBlockId) {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("RecvRealMouseMoveEvent")) {
     recordreplay::OnMouseEvent(this, aEvent);
   }
 
@@ -1712,7 +1712,7 @@ mozilla::ipc::IPCResult BrowserChild::RecvNormalPrioritySynthMouseMoveEvent(
 mozilla::ipc::IPCResult BrowserChild::RecvRealMouseButtonEvent(
     const WidgetMouseEvent& aEvent, const ScrollableLayerGuid& aGuid,
     const uint64_t& aInputBlockId) {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("RecvRealMouseButtonEvent")) {
     recordreplay::OnMouseEvent(this, aEvent);
   }
 
@@ -2124,7 +2124,7 @@ mozilla::ipc::IPCResult BrowserChild::RecvRealKeyEvent(
   MOZ_ASSERT_IF(aEvent.mMessage == eKeyPress,
                 aEvent.AreAllEditCommandsInitialized());
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("RecvRealKeyEvent")) {
     recordreplay::OnKeyboardEvent(this, aEvent);
   }
 
@@ -3734,7 +3734,7 @@ NS_IMETHODIMP BrowserChild::OnLocationChange(nsIWebProgress* aWebProgress,
         "Toplevel content BrowsingContext which isn't GetBrowsingContext()?");
 
     // Record top-level document navigation in the browser child.
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("OnLocationChange")) {
       recordreplay::OnLocationChange(this, aLocation, aFlags);
     }
 

--- a/dom/ipc/ProcessHangMonitor.cpp
+++ b/dom/ipc/ProcessHangMonitor.cpp
@@ -339,7 +339,7 @@ bool HangMonitorChild::InterruptCallback() {
   // The interrupt callback is triggered at non-deterministic points when
   // recording/replaying, so don't perform any operations that can interact
   // with the recording.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("HangMonitorChild::InterruptCallback")) {
     return true;
   }
 

--- a/dom/media/CubebUtils.cpp
+++ b/dom/media/CubebUtils.cpp
@@ -447,7 +447,7 @@ cubeb* GetCubebContextUnlocked() {
              PREF_CUBEB_FORCE_NULL_CONTEXT));
     return nullptr;
   }
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("GetCubebContextUnlocked")) {
     // Media is not supported when recording or replaying.
     recordreplay::ReportUnsupportedFeature("MediaPlayback", 54);
     return nullptr;

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -356,7 +356,7 @@ void MediaFormatReader::DecoderFactory::DoCreateDecoder(Data& aData) {
   }
 
   // Media playback is not supported when recording or replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("DecoderFactory::DoCreateDecoder")) {
     recordreplay::ReportUnsupportedFeature("MediaPlayback", 54);
     return;
   }

--- a/dom/media/UnderrunHandlerLinux.cpp
+++ b/dom/media/UnderrunHandlerLinux.cpp
@@ -24,7 +24,7 @@ void InstallSoftRealTimeLimitHandler() {
   // For now this is disabled when recording/replaying, as the
   // tests of the sigaction() result will behave differently
   // when replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("InstallSoftRealTimeLimitHandler")) {
     return;
   }
 

--- a/dom/media/encoder/MediaEncoder.cpp
+++ b/dom/media/encoder/MediaEncoder.cpp
@@ -661,7 +661,7 @@ already_AddRefed<MediaEncoder> MediaEncoder::CreateEncoder(
   AUTO_PROFILER_LABEL("MediaEncoder::CreateEncoder", OTHER);
 
   // Media encoding isn't supported when recording/replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("MediaEncoder::CreateEncoder")) {
     recordreplay::ReportUnsupportedFeature("Media encoding", 706);
     return nullptr;
   }

--- a/dom/media/platforms/apple/AppleDecoderModule.cpp
+++ b/dom/media/platforms/apple/AppleDecoderModule.cpp
@@ -126,7 +126,7 @@ bool AppleDecoderModule::IsVideoSupported(
 
 /* static */
 bool AppleDecoderModule::CanCreateVP9Decoder() {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("CanCreateVP9Decoder")) {
     return false;
   }
 
@@ -157,7 +157,7 @@ bool AppleDecoderModule::CanCreateVP9Decoder() {
 
 /* static */
 bool AppleDecoderModule::RegisterSupplementalVP9Decoder() {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("RegisterSupplementalVP9Decoder")) {
     return false;
   }
   static bool sRegisterIfAvailable = []() {

--- a/dom/media/platforms/wmf/WMFDecoderModule.cpp
+++ b/dom/media/platforms/wmf/WMFDecoderModule.cpp
@@ -87,7 +87,7 @@ static bool IsRemoteAcceleratedCompositor(
 }
 
 static bool CanCreateMFTDecoder(const GUID& aGuid) {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("CanCreateMFTDecoder")) {
     recordreplay::ReportUnsupportedFeature("MediaPlayback", 54);
     return false;
   }

--- a/dom/media/webaudio/AudioContext.cpp
+++ b/dom/media/webaudio/AudioContext.cpp
@@ -253,7 +253,7 @@ already_AddRefed<AudioContext> AudioContext::Constructor(
     const GlobalObject& aGlobal, const AudioContextOptions& aOptions,
     ErrorResult& aRv) {
   // Audio playback is not yet supported when recording or replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("AudioContext::Constructor")) {
     recordreplay::ReportUnsupportedFeature("WebAudio", 55);
     aRv.Throw(NS_ERROR_NOT_AVAILABLE);
     return nullptr;
@@ -307,7 +307,7 @@ already_AddRefed<AudioContext> AudioContext::Constructor(
     const GlobalObject& aGlobal, uint32_t aNumberOfChannels, uint32_t aLength,
     float aSampleRate, ErrorResult& aRv) {
   // Audio playback is not yet supported when recording or replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("AudioContext::Constructor2")) {
     recordreplay::ReportUnsupportedFeature("WebAudio", 55);
     aRv.Throw(NS_ERROR_NOT_AVAILABLE);
     return nullptr;

--- a/dom/media/webrtc/jsapi/PeerConnectionImpl.cpp
+++ b/dom/media/webrtc/jsapi/PeerConnectionImpl.cpp
@@ -969,7 +969,7 @@ already_AddRefed<TransceiverImpl> PeerConnectionImpl::CreateTransceiverImpl(
     JsepTransceiver* aJsepTransceiver, dom::MediaStreamTrack* aSendTrack,
     ErrorResult& aRv) {
   // WebRTC is disabled when recording/replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("PeerConnectionImpl::CreateTransceiverImpl")) {
     recordreplay::ReportUnsupportedFeature("WebRTC", 56);
     aRv.Throw(NS_ERROR_FAILURE);
     return already_AddRefed<TransceiverImpl>();

--- a/dom/script/ScriptLoader.cpp
+++ b/dom/script/ScriptLoader.cpp
@@ -1633,7 +1633,7 @@ nsresult ScriptLoader::StartLoad(ScriptLoadRequest* aRequest) {
       !js::GlobalHasInstrumentation(globalObject->GetGlobalJSObject()) &&
       // When recording/replaying, scripts have instrumentation when replaying
       // but not when recording.
-      !recordreplay::IsRecordingOrReplaying() &&
+      !recordreplay::IsRecordingOrReplaying("ScriptLoader::StartLoad") &&
       // Bug 1436400: no bytecode cache support for modules yet.
       !aRequest->IsModuleRequest()) {
     MOZ_ASSERT(!aRequest->GetWebExtGlobal(),

--- a/dom/workers/RuntimeService.cpp
+++ b/dom/workers/RuntimeService.cpp
@@ -511,7 +511,7 @@ bool InterruptCallback(JSContext* aCx) {
   // As with the main thread, the interrupt callback is triggered
   // non-deterministically when recording/replaying, so return early to avoid
   // performing any recorded events.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("InterruptCallback")) {
     return true;
   }
 

--- a/gfx/layers/Compositor.cpp
+++ b/gfx/layers/Compositor.cpp
@@ -563,7 +563,7 @@ gfx::IntRect Compositor::ComputeBackdropCopyRect(
 void Compositor::SetInvalid() { mParent = nullptr; }
 
 bool Compositor::IsValid() const {
-  return recordreplay::IsRecordingOrReplaying() || !!mParent;
+  return recordreplay::IsRecordingOrReplaying("Compositor::IsValid") || !!mParent;
 }
 
 void Compositor::UnlockAfterComposition(TextureHost* aTexture) {

--- a/gfx/layers/basic/BasicCompositor.cpp
+++ b/gfx/layers/basic/BasicCompositor.cpp
@@ -924,7 +924,7 @@ Maybe<gfx::IntRect> BasicCompositor::BeginFrameForWindow(
       LayoutDeviceIntRegion::FromUnknownRegion(mInvalidRegion);
   BufferMode bufferMode = BufferMode::BUFFERED;
   RefPtr<DrawTarget> dt;
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("BasicCompositor::BeginFrameForWindow")) {
     bufferMode = BufferMode::BUFFER_NONE;
     dt = recordreplay::DrawTargetForRemoteDrawing(aRenderBounds);
   } else {
@@ -1202,7 +1202,7 @@ void BasicCompositor::EndRemoteDrawing() {
         mFrontBuffer, LayoutDeviceIntRegion::FromUnknownRegion(mInvalidRegion));
 
     mFrontBuffer = nullptr;
-  } else if (!recordreplay::IsRecordingOrReplaying()) {
+  } else if (!recordreplay::IsRecordingOrReplaying("BasicCompositor::EndRemoteDrawing")) {
     mWidget->EndRemoteDrawingInRegion(
         mRenderTarget->mDrawTarget,
         LayoutDeviceIntRegion::FromUnknownRegion(mInvalidRegion));

--- a/gfx/layers/client/ClientLayerManager.cpp
+++ b/gfx/layers/client/ClientLayerManager.cpp
@@ -779,7 +779,7 @@ bool ClientLayerManager::AreComponentAlphaLayersEnabled() {
          // The replaying process uses an in process basic compositor, however.
          // Because layers will be passed to both compositors, we have to avoid
          // using features which aren't supported by the basic compositor.
-         !recordreplay::IsRecordingOrReplaying();
+         !recordreplay::IsRecordingOrReplaying("ClientLayerManager::AreComponentAlphaLayersEnabled");
 }
 
 void ClientLayerManager::SetIsFirstPaint() { mForwarder->SetIsFirstPaint(); }

--- a/gfx/layers/client/TextureClient.cpp
+++ b/gfx/layers/client/TextureClient.cpp
@@ -1102,7 +1102,7 @@ bool TextureClient::InitIPDLActor(CompositableForwarder* aForwarder) {
     LockActor();
   }
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("TextureClient::InitIPDLActor-Forwarder")) {
     recordreplay::RegisterTextureChild(mActor, mData, desc, GetFlags());
   }
 
@@ -1171,7 +1171,7 @@ bool TextureClient::InitIPDLActor(KnowsCompositor* aKnowsCompositor) {
     LockActor();
   }
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("TextureClient::InitIPDLActor-Compositor")) {
     recordreplay::RegisterTextureChild(mActor, mData, desc, GetFlags());
   }
 

--- a/gfx/layers/composite/LayerManagerComposite.cpp
+++ b/gfx/layers/composite/LayerManagerComposite.cpp
@@ -590,7 +590,7 @@ void LayerManagerComposite::UpdateAndRender() {
 
   // Avoid accessing environment when recording/replaying, as this code does
   // not consistently run.
-  if (!recordreplay::IsRecordingOrReplaying() && gfxEnv::SkipComposition()) {
+  if (!recordreplay::IsRecordingOrReplaying("LayerManagerComposite::UpdateAndRender") && gfxEnv::SkipComposition()) {
     mInvalidRegion.SetEmpty();
     return;
   }

--- a/gfx/layers/composite/TiledContentHost.cpp
+++ b/gfx/layers/composite/TiledContentHost.cpp
@@ -295,14 +295,14 @@ bool TiledLayerBufferComposite::UseTiles(const SurfaceDescriptorTiles& aTiles,
     const TexturedTileDescriptor& texturedDesc =
         tileDesc.get_TexturedTileDescriptor();
 
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("TiledLayerBufferComposite::UseTiles")) {
       tile.mTextureHost =
           recordreplay::CreateTextureHost(texturedDesc.textureChild());
     } else {
       tile.mTextureHost =
           TextureHost::AsTextureHost(texturedDesc.textureParent());
     }
-    if (!recordreplay::IsRecordingOrReplaying() && texturedDesc.readLocked()) {
+    if (!recordreplay::IsRecordingOrReplaying("TiledLayerBufferComposite::UseTiles") && texturedDesc.readLocked()) {
       tile.mTextureHost->SetReadLocked();
       auto actor = tile.mTextureHost->GetIPDLActor();
       if (actor && tile.mTextureHost->IsDirectMap()) {
@@ -316,7 +316,7 @@ bool TiledLayerBufferComposite::UseTiles(const SurfaceDescriptorTiles& aTiles,
       }
     }
 
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("TiledLayerBufferComposite::UseTiles")) {
       if (texturedDesc.textureOnWhiteChild().isSome()) {
         tile.mTextureHostOnWhite =
           recordreplay::CreateTextureHost(texturedDesc.textureOnWhiteChild().ref());

--- a/gfx/layers/ipc/CompositableTransactionParent.cpp
+++ b/gfx/layers/ipc/CompositableTransactionParent.cpp
@@ -131,18 +131,18 @@ bool CompositableParentManager::ReceiveCompositableUpdate(
             tileDesc.get_TexturedTileDescriptor();
 
         RefPtr<TextureHost> texture;
-        if (recordreplay::IsRecordingOrReplaying()) {
+        if (recordreplay::IsRecordingOrReplaying("CompositableParentManager::ReceiveCompositableUpdate")) {
           texture = recordreplay::CreateTextureHost(texturedDesc.textureChild());
         } else {
           texture = TextureHost::AsTextureHost(texturedDesc.textureParent());
         }
-        if (texture && !recordreplay::IsRecordingOrReplaying()) {
+        if (texture && !recordreplay::IsRecordingOrReplaying("CompositableParentManager::ReceiveCompositableUpdate")) {
           texture->SetLastFwdTransactionId(mFwdTransactionId);
           // Make sure that each texture was handled by the compositable
           // because the recycling logic depends on it.
           MOZ_ASSERT(texture->NumCompositableRefs() > 0);
         }
-        if (recordreplay::IsRecordingOrReplaying()) {
+        if (recordreplay::IsRecordingOrReplaying("CompositableParentManager::ReceiveCompositableUpdate")) {
           if (texturedDesc.textureOnWhiteChild().isSome()) {
             texture = recordreplay::CreateTextureHost(texturedDesc.textureOnWhiteChild().ref());
           }
@@ -177,7 +177,7 @@ bool CompositableParentManager::ReceiveCompositableUpdate(
       AutoTArray<CompositableHost::TimedTexture, 4> textures;
       for (auto& timedTexture : op.textures()) {
         CompositableHost::TimedTexture* t = textures.AppendElement();
-        if (recordreplay::IsRecordingOrReplaying()) {
+        if (recordreplay::IsRecordingOrReplaying("CompositableParentManager::ReceiveCompositableUpdate")) {
           t->mTexture = recordreplay::CreateTextureHost(timedTexture.textureChild());
         } else {
           t->mTexture = TextureHost::AsTextureHost(timedTexture.textureParent());
@@ -215,7 +215,7 @@ bool CompositableParentManager::ReceiveCompositableUpdate(
       const OpUseComponentAlphaTextures& op =
           aDetail.get_OpUseComponentAlphaTextures();
       RefPtr<TextureHost> texOnBlack, texOnWhite;
-      if (recordreplay::IsRecordingOrReplaying()) {
+      if (recordreplay::IsRecordingOrReplaying("CompositableParentManager::ReceiveCompositableUpdate")) {
         texOnBlack = recordreplay::CreateTextureHost(op.textureOnBlackChild());
         texOnWhite = recordreplay::CreateTextureHost(op.textureOnWhiteChild());
       } else {

--- a/gfx/layers/ipc/CompositorBridgeParent.cpp
+++ b/gfx/layers/ipc/CompositorBridgeParent.cpp
@@ -913,14 +913,14 @@ void CompositorBridgeParent::CompositeToTarget(VsyncId aId, DrawTarget* aTarget,
 
   mCompositionManager->ComputeRotation();
 
-  SampleTime time = recordreplay::IsRecordingOrReplaying()
+  SampleTime time = recordreplay::IsRecordingOrReplaying("CompositorBridgeParent::CompositeToTarget")
     ? SampleTime::FromTest(recordreplay::CompositeTime())
     : (mTestTime ? SampleTime::FromTest(*mTestTime)
                  : mCompositorScheduler->GetLastComposeTime());
   bool requestNextFrame =
       mCompositionManager->TransformShadowTree(time, mVsyncRate);
 
-  if (requestNextFrame && !recordreplay::IsRecordingOrReplaying()) {
+  if (requestNextFrame && !recordreplay::IsRecordingOrReplaying("CompositorBridgeParent::CompositeToTarget")) {
     ScheduleComposition();
   }
 
@@ -1401,7 +1401,7 @@ void CompositorBridgeParent::InitializeLayerManager(
 void CompositorBridgeParent::SetLayerManager(HostLayerManager* aLayerManager) {
   mLayerManager = aLayerManager;
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("CompositorBridgeParent::SetLayerManager")) {
     mCompositionManager = new AsyncCompositionManager(this, mLayerManager);
   }
 }

--- a/gfx/layers/ipc/CompositorManagerChild.cpp
+++ b/gfx/layers/ipc/CompositorManagerChild.cpp
@@ -146,7 +146,7 @@ CompositorManagerChild::CreateWidgetCompositorBridge(
 already_AddRefed<CompositorBridgeChild>
 CompositorManagerChild::CreateSameProcessWidgetCompositorBridge(
     LayerManager* aLayerManager, uint32_t aNamespace) {
-  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying());
+  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying("CompositorManagerChild::CreateSameProcessWidgetCompositorBridge"));
   MOZ_ASSERT(NS_IsMainThread());
   if (NS_WARN_IF(!sInstance || !sInstance->CanSend())) {
     return nullptr;

--- a/gfx/layers/ipc/CompositorManagerParent.cpp
+++ b/gfx/layers/ipc/CompositorManagerParent.cpp
@@ -31,7 +31,7 @@ StaticAutoPtr<nsTArray<CompositorManagerParent*>>
 /* static */
 already_AddRefed<CompositorManagerParent>
 CompositorManagerParent::CreateSameProcess() {
-  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying());
+  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying("CompositorManagerParent::CreateSameProcess"));
   MOZ_ASSERT(NS_IsMainThread());
   StaticMutexAutoLock lock(sMutex);
 
@@ -79,7 +79,7 @@ already_AddRefed<CompositorBridgeParent>
 CompositorManagerParent::CreateSameProcessWidgetCompositorBridge(
     CSSToLayoutDeviceScale aScale, const CompositorOptions& aOptions,
     bool aUseExternalSurfaceSize, const gfx::IntSize& aSurfaceSize) {
-  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying());
+  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying("CompositorManagerParent::CreateSameProcessWidgetCompositorBridge"));
   MOZ_ASSERT(NS_IsMainThread());
 
   // When we are in a combined UI / GPU process, InProcessCompositorSession

--- a/gfx/layers/ipc/CompositorVsyncScheduler.cpp
+++ b/gfx/layers/ipc/CompositorVsyncScheduler.cpp
@@ -82,7 +82,7 @@ CompositorVsyncScheduler::CompositorVsyncScheduler(
   mAsapScheduling =
       StaticPrefs::layers_offmainthreadcomposition_frame_rate() == 0 ||
       gfxPlatform::IsInLayoutAsapMode() ||
-      recordreplay::IsRecordingOrReplaying();
+      recordreplay::IsRecordingOrReplaying("CompositorVsyncScheduler::CompositorVsyncScheduler");
 }
 
 CompositorVsyncScheduler::~CompositorVsyncScheduler() {

--- a/gfx/layers/ipc/LayerTransactionParent.cpp
+++ b/gfx/layers/ipc/LayerTransactionParent.cpp
@@ -875,7 +875,7 @@ bool LayerTransactionParent::DeallocShmem(ipc::Shmem& aShmem) {
 }
 
 bool LayerTransactionParent::IsSameProcess() const {
-  return recordreplay::IsRecordingOrReplaying() ||
+  return recordreplay::IsRecordingOrReplaying("LayerTransactionParent::IsSameProcess") ||
     OtherPid() == base::GetCurrentProcId();
 }
 

--- a/gfx/layers/ipc/ShadowLayers.cpp
+++ b/gfx/layers/ipc/ShadowLayers.cpp
@@ -700,7 +700,7 @@ bool ShadowLayerForwarder::EndTransaction(
   // finish. If it does we don't have to delay messages at all.
   GetCompositorBridgeChild()->PostponeMessagesIfAsyncPainting();
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("ShadowLayerForwarder::EndTransaction")) {
     recordreplay::SendUpdate(mShadowManager, info);
   }
 
@@ -772,7 +772,7 @@ void ShadowLayerForwarder::ReleaseLayer(const LayerHandle& aHandle) {
   if (!IPCOpen()) {
     return;
   }
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("ShadowLayerForwarder::ReleaseLayer")) {
     recordreplay::SendReleaseLayer(mShadowManager, aHandle);
   }
   Unused << mShadowManager->SendReleaseLayer(aHandle);
@@ -818,7 +818,7 @@ void ShadowLayerForwarder::Connect(CompositableClient* aCompositable,
   aCompositable->InitIPDL(handle);
   mShadowManager->SendNewCompositable(handle, aCompositable->GetTextureInfo());
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("ShadowLayerForwarder::Connect")) {
     recordreplay::SendNewCompositable(mShadowManager, handle,
                                       aCompositable->GetTextureInfo());
   }
@@ -1040,7 +1040,7 @@ void ShadowLayerForwarder::ReleaseCompositable(
     if (!IPCOpen()) {
       return;
     }
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("ShadowLayerForwarder::ReleaseCompositable")) {
       recordreplay::SendReleaseCompositable(mShadowManager, aHandle);
     }
     mShadowManager->SendReleaseCompositable(aHandle);

--- a/gfx/thebes/gfxPlatform.cpp
+++ b/gfx/thebes/gfxPlatform.cpp
@@ -818,7 +818,7 @@ void gfxPlatform::Init() {
 
   gfxConfig::Init();
 
-  if (XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying()) {
+  if (XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying("gfxPlatform::Init")) {
     GPUProcessManager::Initialize();
     RDDProcessManager::Initialize();
 
@@ -1321,12 +1321,12 @@ void gfxPlatform::InitLayersIPC() {
   sLayersIPCIsUp = true;
 
   if (XRE_IsContentProcess()) {
-    if (gfxVars::UseOMTP() && !recordreplay::IsRecordingOrReplaying()) {
+    if (gfxVars::UseOMTP() && !recordreplay::IsRecordingOrReplaying("gfxPlatform::InitLayersIPC")) {
       layers::PaintThread::Start();
     }
   }
 
-  if (XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying()) {
+  if (XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying("gfxPlatform::InitLayersIPC")) {
     if (!gfxConfig::IsEnabled(Feature::GPU_PROCESS) && UseWebRender()) {
       wr::RenderThread::Start();
       image::ImageMemoryReporter::InitForWebRender();
@@ -1351,7 +1351,7 @@ void gfxPlatform::ShutdownLayersIPC() {
       layers::ImageBridgeChild::ShutDown();
     }
 
-    if (gfxVars::UseOMTP() && !recordreplay::IsRecordingOrReplaying()) {
+    if (gfxVars::UseOMTP() && !recordreplay::IsRecordingOrReplaying("gfxPlatform::ShutdownLayersIPC")) {
       layers::PaintThread::Shutdown();
     }
   } else if (XRE_IsParentProcess()) {
@@ -2616,7 +2616,7 @@ void gfxPlatform::InitCompositorAccelerationPrefs() {
   // universally disable compositing as otherwise our disable below will be
   // overwritten later during initialization.
 #ifndef XP_WIN
-  if (recordreplay::IsRecordingOrReplaying())
+  if (recordreplay::IsRecordingOrReplaying("gfxPlatform::InitCompositorAccelerationPrefs"))
 #endif
   {
     feature.ForceDisable(
@@ -2675,7 +2675,7 @@ void gfxPlatform::InitWebRenderConfig() {
   if (!XRE_IsParentProcess()) {
     // Force-disable WebRender in recording/replaying child processes, which
     // have their own compositor.
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("gfxPlatform::InitCompositorAccelerationPrefs")) {
       gfxVars::SetUseWebRender(false);
     }
 
@@ -2726,7 +2726,7 @@ void gfxPlatform::InitWebRenderConfig() {
 
   // gfxFeature is not usable in the GPU process, so we use gfxVars to transmit
   // this feature
-  if (hasWebRender && !recordreplay::IsRecordingOrReplaying()) {
+  if (hasWebRender && !recordreplay::IsRecordingOrReplaying("gfxPlatform::InitWebRenderConfig")) {
     gfxVars::SetUseWebRender(true);
     reporter.SetSuccessful();
 
@@ -3049,7 +3049,7 @@ bool gfxPlatform::IsInLayoutAsapMode() {
 /* static */
 bool gfxPlatform::ForceSoftwareVsync() {
   return StaticPrefs::layout_frame_rate() > 0 ||
-         recordreplay::IsRecordingOrReplaying();
+         recordreplay::IsRecordingOrReplaying("gfxPlatform::ForceSoftwareVsync");
 }
 
 /* static */
@@ -3066,7 +3066,7 @@ int gfxPlatform::GetDefaultFrameRate() { return 60; }
 
 /* static */
 void gfxPlatform::ReInitFrameRate() {
-  if (XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying()) {
+  if (XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying("gfxPlatform::ReInitFrameRate")) {
     RefPtr<VsyncSource> oldSource = gPlatform->mVsyncSource;
 
     // Start a new one:

--- a/gfx/thebes/gfxPlatform.h
+++ b/gfx/thebes/gfxPlatform.h
@@ -689,7 +689,7 @@ class gfxPlatform : public mozilla::layers::MemoryPressureListener {
   virtual mozilla::gfx::VsyncSource* GetHardwareVsync() {
     MOZ_ASSERT(mVsyncSource != nullptr);
     MOZ_ASSERT(XRE_IsParentProcess() ||
-               mozilla::recordreplay::IsRecordingOrReplaying());
+               mozilla::recordreplay::IsRecordingOrReplaying("gfxPlatform::GetHardwareVsync"));
     return mVsyncSource;
   }
 

--- a/image/SurfaceCache.cpp
+++ b/image/SurfaceCache.cpp
@@ -64,7 +64,7 @@ static OrderedStaticMutex sInstanceMutex;
 
 // We need to initialize the mutex on a consistent thread when recording/replaying.
 void RecordReplayInitializeSurfaceCacheMutex() {
-  MOZ_ASSERT(recordreplay::IsRecordingOrReplaying());
+  MOZ_ASSERT(recordreplay::IsRecordingOrReplaying("RecordReplayInitializeSurfaceCacheMutext"));
   OrderedStaticMutexAutoLock lock(sInstanceMutex);
 }
 

--- a/ipc/chromium/src/mojo/core/ports/port_locker.cc
+++ b/ipc/chromium/src/mojo/core/ports/port_locker.cc
@@ -33,7 +33,7 @@ void UpdateTLS(PortLocker* old_locker, PortLocker* new_locker) {
 static uintptr_t GetPortId(Port* port) {
   // When recording/replaying the sorted order of ports need to be consistent,
   // so we use the ID associated with the port via RegisterThing for sorting.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("mojo::core::ports::GetPortId")) {
     uintptr_t id = mozilla::recordreplay::ThingIndex(port);
     CHECK(id);
     return id;

--- a/ipc/glue/MessagePump.cpp
+++ b/ipc/glue/MessagePump.cpp
@@ -82,7 +82,7 @@ void MessagePump::Run(MessagePump::Delegate* aDelegate) {
   for (;;) {
     autoReleasePool.Recycle();
 
-    if (mozilla::recordreplay::IsRecordingOrReplaying() && NS_IsMainThread()) {
+    if (mozilla::recordreplay::IsRecordingOrReplaying("MessagePump::Run") && NS_IsMainThread()) {
       mozilla::recordreplay::MaybeCreateCheckpoint();
     }
 

--- a/ipc/glue/ProtocolUtils.cpp
+++ b/ipc/glue/ProtocolUtils.cpp
@@ -976,7 +976,7 @@ static MOZ_THREAD_LOCAL(uint32_t) gNumRecordReplayAssertMessageContents;
 static std::atomic<bool> gNumRecordReplayAssertMessageContentsInitialized;
 
 AutoRecordReplayAssertMessageContents::AutoRecordReplayAssertMessageContents() {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("AutoRecordReplayAssertMessageContents::AutoRecordReplayAssertMessageContents")) {
     if (!gNumRecordReplayAssertMessageContentsInitialized) {
       // Hopefully this won't race...
       gNumRecordReplayAssertMessageContents.init();
@@ -987,13 +987,13 @@ AutoRecordReplayAssertMessageContents::AutoRecordReplayAssertMessageContents() {
 }
 
 AutoRecordReplayAssertMessageContents::~AutoRecordReplayAssertMessageContents() {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("AutoRecordReplayAssertMessageContents::~AutoRecordReplayAssertMessageContents")) {
     gNumRecordReplayAssertMessageContents.set(gNumRecordReplayAssertMessageContents.get() - 1);
   }
 }
 
 bool ShouldRecordReplayAssertMessageContents() {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("ShouldRecordReplayAssertMessageContents")) {
     return gNumRecordReplayAssertMessageContentsInitialized &&
       gNumRecordReplayAssertMessageContents.get() > 0;
   }

--- a/js/ductwork/debugger/JSDebugger.cpp
+++ b/js/ductwork/debugger/JSDebugger.cpp
@@ -55,7 +55,7 @@ JSDebugger::AddClass(JS::Handle<JS::Value> global, JSContext* cx) {
     return NS_ERROR_FAILURE;
   }
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("JSDebugger::AddClass")) {
     if (!recordreplay::DefineRecordReplayControlObject(cx, obj)) {
       return NS_ERROR_FAILURE;
     }

--- a/js/src/builtin/Array.cpp
+++ b/js/src/builtin/Array.cpp
@@ -1818,7 +1818,7 @@ enum ComparatorMatchResult {
  */
 static ComparatorMatchResult MatchNumericComparator(JSContext* cx,
                                                     JSObject* obj) {
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("js::Array::MatchNumericComparator")) {
     return Match_None;
   }
 

--- a/js/src/builtin/Eval.cpp
+++ b/js/src/builtin/Eval.cpp
@@ -270,7 +270,7 @@ static bool EvalKernel(JSContext* cx, HandleValue v, EvalType evalType,
       // The eval cache is purged at non-deterministic points during GC, and affects
       // when the debugger's new script notification fires. Disable the cache when
       // recording/replaying to avoid this non-determinism.
-      !mozilla::recordreplay::IsRecordingOrReplaying()) {
+      !mozilla::recordreplay::IsRecordingOrReplaying("js::EvalKernel")) {
     esg.lookupInEvalCache(linearStr, callerScript, pc);
   }
 

--- a/js/src/builtin/Promise.cpp
+++ b/js/src/builtin/Promise.cpp
@@ -5852,7 +5852,7 @@ bool JS::AutoDebuggerJobQueueInterruption::init(JSContext* cx) {
   // at different places between recording and replay. Because nested event
   // loops aren't pushed in debugger callbacks when recording/replaying, the
   // job queue does not need to be saved during debugger callbacks.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("JS::AutoDebuggerJobQueueInterruption::init")) {
     return true;
   }
 
@@ -5863,7 +5863,7 @@ bool JS::AutoDebuggerJobQueueInterruption::init(JSContext* cx) {
 }
 
 void JS::AutoDebuggerJobQueueInterruption::runJobs() {
-  if (!mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (!mozilla::recordreplay::IsRecordingOrReplaying("JS::AutoDebuggerJobQueueInterruption::runJobs")) {
     JS::AutoSaveExceptionState ases(cx);
     cx->jobQueue->runJobs(cx);
   }

--- a/js/src/debugger/DebugAPI-inl.h
+++ b/js/src/debugger/DebugAPI-inl.h
@@ -139,7 +139,7 @@ bool DebugAPI::onDebuggerStatement(JSContext* cx, AbstractFramePtr frame) {
 
 /* static */
 bool DebugAPI::onExceptionUnwind(JSContext* cx, AbstractFramePtr frame) {
-  if (mozilla::recordreplay::IsRecordingOrReplaying() && cx->isThrowingOutOfMemory()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("DebugAPI::onExceptionUnwind") && cx->isThrowingOutOfMemory()) {
     mozilla::recordreplay::InvalidateRecording("OutOfMemory exception unwind");
   }
   if (MOZ_UNLIKELY(cx->realm()->isDebuggee())) {

--- a/js/src/debugger/Debugger.cpp
+++ b/js/src/debugger/Debugger.cpp
@@ -6098,7 +6098,7 @@ bool Debugger::recordReplayProcessKind(JSContext* cx, unsigned argc,
                                        Value* vp) {
   CallArgs args = CallArgsFromVp(argc, vp);
 
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("Debugger::recordReplayProcessKind")) {
     JSString* str = JS_NewStringCopyZ(cx, "RecordingReplaying");
     if (!str) {
       return false;

--- a/js/src/ds/MemoryProtectionExceptionHandler.cpp
+++ b/js/src/ds/MemoryProtectionExceptionHandler.cpp
@@ -126,7 +126,7 @@ bool MemoryProtectionExceptionHandler::isDisabled() {
 #elif defined(__wasi__)
   return true;
 #else
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("MemoryProtectionExceptionHandler::isDisabled")) {
     return true;
   }
   return false;

--- a/js/src/frontend/BytecodeCompiler.cpp
+++ b/js/src/frontend/BytecodeCompiler.cpp
@@ -626,7 +626,7 @@ bool frontend::SourceAwareCompiler<Unit>::createSourceAndParser(JSContext* cx) {
     return false;
   }
   // Note the contents of any compiled scripts when recording/replaying.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("frontend::SourceAwareCompiler<Unit>::createSourceAndParser")) {
     mozilla::recordreplay::NoteContentParse(
         this, options.filename(), "application/javascript",
         sourceBuffer_.units(), sourceBuffer_.length());

--- a/js/src/frontend/BytecodeEmitter.cpp
+++ b/js/src/frontend/BytecodeEmitter.cpp
@@ -159,7 +159,7 @@ BytecodeEmitter::BytecodeEmitter(BytecodeEmitter* parent,
                                  EmitterMode emitterMode)
     : BytecodeEmitter(parent, sc, compilationState, emitterMode) {
   parser = handle;
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("BytecodeEmitter::BytecodeEmitter.1")) {
     instrumentationKinds = RealmInstrumentation::getInstrumentationKinds(cx->global());
   }
 }
@@ -171,7 +171,7 @@ BytecodeEmitter::BytecodeEmitter(BytecodeEmitter* parent,
     : BytecodeEmitter(parent, sc, compilationState, emitterMode) {
   ep_.emplace(parser);
   this->parser = ep_.ptr();
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("BytecodeEmitter::BytecodeEmitter.2")) {
     instrumentationKinds = RealmInstrumentation::getInstrumentationKinds(cx->global());
   }
 }

--- a/js/src/frontend/BytecodeEmitter.h
+++ b/js/src/frontend/BytecodeEmitter.h
@@ -1034,7 +1034,7 @@ struct MOZ_STACK_CLASS BytecodeEmitter {
   // Controls whether execution progress and the corresponding instrumentation
   // opcodes will be emitted for tracking execution when recording/replaying.
   bool shouldEmitInstrumentation() {
-    if (mozilla::recordreplay::IsRecordingOrReplaying() &&
+    if (mozilla::recordreplay::IsRecordingOrReplaying("BytecodeEmitter::shouldEmitInstrumentation") &&
         instrumentationKinds &&
         mozilla::recordreplay::ShouldUpdateProgressCounter(parser->options().filename())) {
       MOZ_RELEASE_ASSERT(emitterMode != BytecodeEmitter::SelfHosting);

--- a/js/src/frontend/FullParseHandler.h
+++ b/js/src/frontend/FullParseHandler.h
@@ -1091,7 +1091,7 @@ class FullParseHandler {
   bool disableWarnings() const {
     // Full parsing occurs at non-deterministic points when recording/replaying,
     // so warnings are not emitted.
-    return mozilla::recordreplay::IsRecordingOrReplaying();
+    return mozilla::recordreplay::IsRecordingOrReplaying("FullParseHandler::disableWarnings");
   }
 
   bool canSkipLazyInnerFunctions() { return !!lazyOuterFunction_; }

--- a/js/src/gc/GC.cpp
+++ b/js/src/gc/GC.cpp
@@ -2137,7 +2137,7 @@ bool GCRuntime::shouldCompact() {
 bool GCRuntime::isCompactingGCEnabled() const {
   return compactingEnabled &&
          rt->mainContextFromOwnThread()->compactingDisabledCount == 0 &&
-         !mozilla::recordreplay::IsRecordingOrReplaying();
+         !mozilla::recordreplay::IsRecordingOrReplaying("GCRuntime::isCompactingGCEnabled");
 }
 
 AutoDisableCompactingGC::AutoDisableCompactingGC(JSContext* cx) : cx(cx) {
@@ -8964,7 +8964,7 @@ JS_PUBLIC_API void JS::DisableIncrementalGC(JSContext* cx) {
 JS_PUBLIC_API bool JS::IsIncrementalGCEnabled(JSContext* cx) {
   GCRuntime& gc = cx->runtime()->gc;
   return gc.isIncrementalGCEnabled() && gc.isIncrementalGCAllowed() &&
-         !mozilla::recordreplay::IsRecordingOrReplaying();
+         !mozilla::recordreplay::IsRecordingOrReplaying("JS::IsIncrementalGCEnabled");
 }
 
 JS_PUBLIC_API bool JS::IsIncrementalGCInProgress(JSContext* cx) {

--- a/js/src/gc/Memory.cpp
+++ b/js/src/gc/Memory.cpp
@@ -447,7 +447,7 @@ void* MapAlignedPages(size_t length, size_t alignment) {
 #  ifdef JS_64BIT
   // Use the scattershot allocator if the address range is large enough.
   if (UsingScattershotAllocator() &&
-      !mozilla::recordreplay::IsRecordingOrReplaying()) {
+      !mozilla::recordreplay::IsRecordingOrReplaying("js::gc::MapAlignedPages")) {
     void* region = MapAlignedPagesRandom(length, alignment);
 
     MOZ_RELEASE_ASSERT(!IsInvalidRegion(region, length));
@@ -875,7 +875,7 @@ bool MarkPagesInUseHard(void* region, size_t length) {
 }
 
 size_t GetPageFaultCount() {
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("js::gc::GetPageFaultCount")) {
     return 0;
   }
 #ifdef XP_WIN

--- a/js/src/gc/Nursery.cpp
+++ b/js/src/gc/Nursery.cpp
@@ -235,7 +235,7 @@ static bool GetBoolEnvVar(const char* name, const char* helpMessage) {
 bool js::Nursery::init(AutoLockGCBgAlloc& lock) {
   // The nursery is permanently disabled when recording or replaying. Nursery
   // collections may occur at non-deterministic points in execution.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("js::Nursery::init")) {
     return true;
   }
 
@@ -265,7 +265,7 @@ js::Nursery::~Nursery() { disable(); }
 void js::Nursery::enable() {
   MOZ_ASSERT(isEmpty());
   MOZ_ASSERT(!gc->isVerifyPreBarriersEnabled());
-  if (isEnabled() || mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (isEnabled() || mozilla::recordreplay::IsRecordingOrReplaying("js::Nursery::enable")) {
     return;
   }
 

--- a/js/src/jit/BaselineCodeGen.cpp
+++ b/js/src/jit/BaselineCodeGen.cpp
@@ -2177,7 +2177,7 @@ bool BaselineCodeGen<Handler>::emit_LoopHead() {
 
 template <typename Handler>
 bool BaselineCodeGen<Handler>::emit_ExecutionProgress() {
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("BaselineCodeGen<Handler>::emit_ExecutionProgress")) {
     if (ExecutionProgressHook) {
       Register scratch = R0.scratchReg();
       loadScript(scratch);
@@ -6976,7 +6976,7 @@ bool BaselineInterpreterGenerator::generate(BaselineInterpreter& interpreter) {
     }
 
     // Register code with the record/replay profiler.
-    if (mozilla::recordreplay::IsRecordingOrReplaying() || mozilla::recordreplay::IsProfiling()) {
+    if (mozilla::recordreplay::IsRecordingOrReplaying("BaselineInterpreterGenerator::generate") || mozilla::recordreplay::IsProfiling()) {
       mozilla::recordreplay::LabelExecutableCode(code->raw(), code->instructionsSize(),
                                                  "SpiderMonkey:BaselineInterpreter");
     }

--- a/js/src/jit/CodeGenerator.cpp
+++ b/js/src/jit/CodeGenerator.cpp
@@ -14346,7 +14346,7 @@ void CodeGenerator::visitInterruptCheck(LInterruptCheck* lir) {
   OutOfLineCode* ool =
       oolCallVM<Fn, InterruptCheck>(lir, ArgList(), StoreNothing());
 
-  if (mozilla::recordreplay::IsRecordingOrReplaying() && gen->runtime->hasParentRuntime()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("CodeGenerator::visitInterruptCheck") && gen->runtime->hasParentRuntime()) {
     // Always call InterruptCheck in worker runtimes when recording/replaying,
     // to make sure NotifyActivity() is called regularly.
     masm.jump(ool->entry());

--- a/js/src/jit/ExecutableAllocator.cpp
+++ b/js/src/jit/ExecutableAllocator.cpp
@@ -74,7 +74,7 @@ void* ExecutablePool::alloc(size_t n, CodeKind kind) {
   void* result = m_freePtr;
   m_freePtr += n;
 
-  if (mozilla::recordreplay::IsRecordingOrReplaying() || mozilla::recordreplay::IsProfiling()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("ExecutablePool::alloc") || mozilla::recordreplay::IsProfiling()) {
     const char* kindStr = nullptr;
     switch (kind) {
       case CodeKind::Ion:

--- a/js/src/jit/ProcessExecutableMemory.cpp
+++ b/js/src/jit/ProcessExecutableMemory.cpp
@@ -254,7 +254,7 @@ static void* ReserveProcessExecutableMemory(size_t bytes) {
 
   // Disabled when recording/replaying, as VirtualAlloc at arbitrary addresses
   // is disallowed when replaying, causing behavior here to diverge.
-  if (!mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (!mozilla::recordreplay::IsRecordingOrReplaying("ReserveProcessExecutableMemory")) {
     for (size_t i = 0; i < 10; i++) {
       void* randomAddr = ComputeRandomAllocationAddress();
       p = VirtualAlloc(randomAddr, bytes, MEM_RESERVE, PAGE_NOACCESS);

--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -407,7 +407,7 @@ JS_PUBLIC_API JSContext* JS_NewContext(uint32_t maxbytes,
 
   // When recording/replaying, force instantiation of lazy wasm signal ahndler
   // state at a consistent point.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("JS_NewContext")) {
     wasm::HasPlatformSupport(cx);
   }
 

--- a/js/src/util/StructuredSpewer.cpp
+++ b/js/src/util/StructuredSpewer.cpp
@@ -41,7 +41,7 @@ bool StructuredSpewer::ensureInitializationAttempted() {
   if (!outputInitializationAttempted_) {
     // We cannot call getenv during record replay, so disable
     // the spewer.
-    if (!mozilla::recordreplay::IsRecordingOrReplaying()) {
+    if (!mozilla::recordreplay::IsRecordingOrReplaying("StructuredSpewer::ensureInitializationAttempted")) {
       char filename[2048] = {0};
       // For ease of use with Treeherder
       if (getenv("SPEW_UPLOAD") && getenv("MOZ_UPLOAD_DIR")) {
@@ -106,7 +106,7 @@ bool StructuredSpewer::enabled(JSScript* script) {
   }
 
   // We cannot call getenv under record/replay.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("StructuredSpewer::enabled")) {
     return false;
   }
   static const char* pattern = getenv("SPEW_FILTER");

--- a/js/src/util/StructuredSpewer.h
+++ b/js/src/util/StructuredSpewer.h
@@ -128,7 +128,7 @@ class StructuredSpewer {
         json_(mozilla::Nothing()),
         selectedChannel_() {
     // If we are recording or replaying, we cannot use getenv
-    if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+    if (mozilla::recordreplay::IsRecordingOrReplaying("StructuredSpewer::StructuredSpewer")) {
       return;
     }
     if (getenv("SPEW")) {

--- a/js/src/vm/DateTime.cpp
+++ b/js/src/vm/DateTime.cpp
@@ -159,7 +159,7 @@ void js::DateTimeInfo::internalResetTimeZone(ResetTimeZoneMode mode) {
   }
 
   // Don't reset time zone status when recording/replaying, see DateTimeInfo().
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("js::DateTimeInfo::internalResetTimeZone")) {
     return;
   }
 
@@ -230,7 +230,7 @@ js::DateTimeInfo::DateTimeInfo() {
   // When recording/replaying the timezone is intialized on startup and never
   // changes afterwards, to avoid problems when updating the time zone
   // non-deterministically from different threads.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("js::DateTimeInfo::DateTimeInfo")) {
     updateTimeZone();
   }
 }

--- a/js/src/vm/EnvironmentObject.cpp
+++ b/js/src/vm/EnvironmentObject.cpp
@@ -2663,7 +2663,7 @@ void DebugEnvironments::takeFrameSnapshot(
 
   // Disable frame snapshots when recording/replaying. These aren't used and
   // this function has caused crashes that seem unrelated to recording/replaying.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("DebugEnvironments::takeFrameSnapshot")) {
     return;
   }
 

--- a/js/src/vm/ErrorObject.cpp
+++ b/js/src/vm/ErrorObject.cpp
@@ -213,7 +213,7 @@ static void exn_finalize(JSFreeOp* fop, JSObject* obj) {
 uint32_t js::NewTimeWarpTarget(JSContext* cx) {
   // When recording/replaying and running on the main thread, get a counter
   // which the devtools can use to warp to this point in the future.
-  if (mozilla::recordreplay::IsRecordingOrReplaying() &&
+  if (mozilla::recordreplay::IsRecordingOrReplaying("js::NewTimeWarpTarget") &&
       !cx->runtime()->parentRuntime) {
     uint64_t warpTarget = mozilla::recordreplay::NewTimeWarpTarget();
 

--- a/js/src/vm/HelperThreads.cpp
+++ b/js/src/vm/HelperThreads.cpp
@@ -1377,7 +1377,7 @@ bool GlobalHelperThreadState::ensureInitialized() {
   // thread tasks are scheduled at non-deterministic points and we don't support
   // scheduling non-deterministic tasks on gecko threads yet.
   // See https://github.com/RecordReplay/backend/issues/1091
-  useInternalThreadPool_ = !dispatchTaskCallback || mozilla::recordreplay::IsRecordingOrReplaying();
+  useInternalThreadPool_ = !dispatchTaskCallback || mozilla::recordreplay::IsRecordingOrReplaying("GlobalHelperThreadState::ensureInitialized");
   if (useInternalThreadPool(lock)) {
     if (!InternalThreadPool::Initialize(threadCount, lock)) {
       return false;
@@ -2676,7 +2676,7 @@ void PromiseHelperTask::runHelperThreadTask(AutoLockHelperThreadState& lock) {
 bool js::StartOffThreadPromiseHelperTask(JSContext* cx,
                                          UniquePtr<PromiseHelperTask> task) {
   // Execute synchronously if there are no helper threads.
-  if (!CanUseExtraThreads() || mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (!CanUseExtraThreads() || mozilla::recordreplay::IsRecordingOrReplaying("js::StartOffThreadPromiseHelperTask")) {
     task.release()->executeAndResolveAndDestroy(cx);
     return true;
   }

--- a/js/src/vm/Initialization.cpp
+++ b/js/src/vm/Initialization.cpp
@@ -235,7 +235,7 @@ JS_PUBLIC_API const char* JS::detail::InitWithFailureDiagnostic(
 #endif
 
 #ifndef XP_WIN
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("JS::detail::InitWithFailureDiagnostic")) {
     if (getenv("RECORD_REPLAY_RECORD_EXECUTION_ASSERTS")) {
       void* hook = dlsym(RTLD_DEFAULT, "RecordReplayInterface_ExecutionProgressHook");
       ExecutionProgressHook = mozilla::BitwiseCast<void(*)(unsigned, const char*, unsigned, unsigned)>(hook);

--- a/js/src/vm/InternalThreadPool.cpp
+++ b/js/src/vm/InternalThreadPool.cpp
@@ -221,7 +221,7 @@ void HelperThread::ThreadMain(InternalThreadPool* pool, HelperThread* helper) {
 }
 
 void HelperThread::ensureRegisteredWithProfiler() {
-  if (profilingStack || mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (profilingStack || mozilla::recordreplay::IsRecordingOrReplaying("HelperThread::ensureRegisteredWithProfiler")) {
     return;
   }
 

--- a/js/src/vm/Interpreter.cpp
+++ b/js/src/vm/Interpreter.cpp
@@ -755,7 +755,7 @@ bool js::ExecuteKernel(JSContext* cx, HandleScript script,
     script->setHasRunOnce();
   }
 
-  if (script->isEmpty() && !mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (script->isEmpty() && !mozilla::recordreplay::IsRecordingOrReplaying("js::ExecuteKernel")) {
     result.setUndefined();
     return true;
   }

--- a/js/src/vm/JSContext-inl.h
+++ b/js/src/vm/JSContext-inl.h
@@ -258,7 +258,7 @@ MOZ_ALWAYS_INLINE bool CallNativeImpl(JSContext* cx, NativeImpl impl,
 MOZ_ALWAYS_INLINE bool CheckForInterrupt(JSContext* cx) {
   MOZ_ASSERT(!cx->isExceptionPending());
 
-  if (mozilla::recordreplay::IsRecordingOrReplaying() &&
+  if (mozilla::recordreplay::IsRecordingOrReplaying("js::CheckForInterrupt") &&
       cx->runtime()->parentRuntime) {
     // Let the record/replay driver know when a long-running operation might be
     // taking place while running off the main thread.

--- a/js/src/vm/JSScript.cpp
+++ b/js/src/vm/JSScript.cpp
@@ -1107,7 +1107,7 @@ XDRResult js::XDRScript(XDRState<mode>* xdr, HandleScope scriptEnclosingScope,
 
   // When recording/replaying, whether globals are instrumented can vary between
   // recording and replaying.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("js::XDRScript")) {
     return xdr->fail(JS::TranscodeResult::Failure);
   }
 
@@ -3085,7 +3085,7 @@ XDRResult ScriptSource::xdrData(XDRState<mode>* const xdr,
 
 // Note the content of sources decoded when recording or replaying.
 static bool MaybeNoteContentParse(JSContext* cx, ScriptSource* ss) {
-  if (!mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (!mozilla::recordreplay::IsRecordingOrReplaying("js::MaybeNoteContentParse")) {
     return true;
   }
   if (!ss->hasSourceText()) {

--- a/js/src/vm/OffThreadScriptCompilation.cpp
+++ b/js/src/vm/OffThreadScriptCompilation.cpp
@@ -65,7 +65,7 @@ static bool CanDoOffThread(JSContext* cx, const ReadOnlyCompileOptions& options,
   }
 
   return cx->runtime()->canUseParallelParsing() && CanUseExtraThreads() &&
-         !mozilla::recordreplay::IsRecordingOrReplaying();
+         !mozilla::recordreplay::IsRecordingOrReplaying("js::CanDoOffThread");
 }
 
 JS_PUBLIC_API bool JS::CanCompileOffThread(

--- a/js/src/vm/Runtime.cpp
+++ b/js/src/vm/Runtime.cpp
@@ -997,7 +997,7 @@ JS_PUBLIC_API void JS::RecordReplayCheckTrackedObject(JSContext* cx, HandleObjec
 }
 
 bool js::RecordReplayAssertValue(JSContext* cx, HandlePropertyName name, HandleValue value) {
-  if (!mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (!mozilla::recordreplay::IsRecordingOrReplaying("js::RecordReplayAssertValue")) {
     MOZ_RELEASE_ASSERT(gForceEmitRecordReplayAsserts);
     return true;
   }

--- a/js/src/vm/SharedArrayObject.cpp
+++ b/js/src/vm/SharedArrayObject.cpp
@@ -254,7 +254,7 @@ SharedArrayBufferObject* SharedArrayBufferObject::New(JSContext* cx,
                                                       size_t length,
                                                       HandleObject proto) {
   // SharedArrayBuffer is not supported when recording/replaying.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("SharedArrayObject::New")) {
     mozilla::recordreplay::ReportUnsupportedFeature("SharedArrayBuffer", 499);
     JS_ReportErrorASCII(cx, "Creating SharedArrayBuffer is not supported when recording/replaying");
     return nullptr;

--- a/js/src/vm/SharedArrayObject.h
+++ b/js/src/vm/SharedArrayObject.h
@@ -80,7 +80,7 @@ class SharedArrayRawBuffer {
         preparedForWasm_(preparedForWasm),
         waiters_(nullptr) {
     MOZ_ASSERT(buffer == dataPointerShared());
-    MOZ_RELEASE_ASSERT(!mozilla::recordreplay::IsRecordingOrReplaying());
+    MOZ_RELEASE_ASSERT(!mozilla::recordreplay::IsRecordingOrReplaying("SharedArrayRawBuffer::SharedArrayRawBuffer"));
   }
 
   // Allocate a SharedArrayRawBuffer for either Wasm or other users.

--- a/js/src/vm/StructuredClone.cpp
+++ b/js/src/vm/StructuredClone.cpp
@@ -588,7 +588,7 @@ struct JSStructuredCloneWriter {
       // preserved during recording/replaying, as the callbacks used
       // during transfer may interact with the recording. Just use the
       // same hash number for all elements to ensure this.
-      if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+      if (mozilla::recordreplay::IsRecordingOrReplaying("TransferableObjectHasher::hash")) {
         return 0;
       }
       return DefaultHasher<JSObject*>::hash(l);

--- a/js/src/vm/Time.h
+++ b/js/src/vm/Time.h
@@ -131,7 +131,7 @@ extern size_t PRMJ_FormatTime(char* buf, size_t buflen, const char* fmt,
 
 #  include <intrin.h>
 static __inline uint64_t ReadTimestampCounter(void) {
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("ReadTimestampCounter")) {
     return 0;
   }
   return __rdtsc();
@@ -140,7 +140,7 @@ static __inline uint64_t ReadTimestampCounter(void) {
 #elif defined(__i386__)
 
 static __inline__ uint64_t ReadTimestampCounter(void) {
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("ReadTimestampCounter")) {
     return 0;
   }
   uint64_t x;
@@ -151,7 +151,7 @@ static __inline__ uint64_t ReadTimestampCounter(void) {
 #elif defined(__x86_64__)
 
 static __inline__ uint64_t ReadTimestampCounter(void) {
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("ReadTimestampCounter")) {
     return 0;
   }
   unsigned hi, lo;

--- a/js/src/vm/Xdr.cpp
+++ b/js/src/vm/Xdr.cpp
@@ -289,7 +289,7 @@ XDRResult XDRState<mode>::codeScript(MutableHandleScript scriptp) {
   // XDR is not supported when recording/replaying, as script contents differ
   // when recording/replaying due to execution progress and instrumentation
   // opcodes.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("XDRState::codeScript")) {
     return fail(JS::TranscodeResult::Failure);
   }
 

--- a/js/src/wasm/WasmDebug.cpp
+++ b/js/src/wasm/WasmDebug.cpp
@@ -281,7 +281,7 @@ void DebugState::clearBreakpointsIn(JSFreeOp* fop, WasmInstanceObject* instance,
 void DebugState::toggleDebugTrap(uint32_t offset, bool enabled) {
   // Refuse to enable debug traps when recording/replaying. Sometimes these get
   // enabled for unclear reasons, causing large performance degradations.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("DebugState::toggleDebugTrap")) {
     enabled = false;
   }
 

--- a/js/src/wasm/WasmJS.cpp
+++ b/js/src/wasm/WasmJS.cpp
@@ -434,7 +434,7 @@ bool wasm::StreamingCompilationAvailable(JSContext* cx) {
          cx->runtime()->offThreadPromiseState.ref().initialized() &&
          CanUseExtraThreads() && cx->runtime()->consumeStreamCallback &&
          cx->runtime()->reportStreamErrorCallback &&
-         !mozilla::recordreplay::IsRecordingOrReplaying();
+         !mozilla::recordreplay::IsRecordingOrReplaying("wasm::StreamingCompilationAvailable");
 }
 
 bool wasm::CodeCachingAvailable(JSContext* cx) {
@@ -4141,7 +4141,7 @@ static bool EnsureStreamSupport(JSContext* cx) {
   // When recording/replaying, promise tasks used by streaming can execute on
   // JS helper threads. These interact with the recording, and are not currently
   // supported.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("wasm::EnsureStreamSupport")) {
     mozilla::recordreplay::ReportUnsupportedFeature("WasmStreaming", 501);
     JS_ReportErrorASCII(cx,
                         "WebAssembly streaming not supported when recording/replaying");

--- a/js/xpconnect/src/XPCJSContext.cpp
+++ b/js/xpconnect/src/XPCJSContext.cpp
@@ -564,7 +564,7 @@ bool XPCJSContext::RecordScriptActivity(bool aActive) {
 
   // Since the slow script dialog never activates if we are recording or
   // replaying, don't record/replay JS activity notifications.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("XPCJSContext::RecordScriptActivity")) {
     return oldValue;
   }
 
@@ -591,7 +591,7 @@ static bool sTelemetryEventEnabled(false);
 bool XPCJSContext::InterruptCallback(JSContext* cx) {
   // The slow script dialog never activates if we are recording or replaying,
   // since the precise timing of the dialog cannot be replayed.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("XPCJSContext::InterruptCallback")) {
     return true;
   }
 
@@ -1144,7 +1144,7 @@ XPCJSContext* XPCJSContext::Get() {
 #ifdef XP_WIN
 static size_t GetWindowsStackSize() {
   // Workaround VirtualQuery not being supported when replaying.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("XPCJSContext::GetWindowsStackSize")) {
     using GetCurrentThreadStackLimitsFn = void(WINAPI*)(PULONG_PTR LowLimit,
                                                         PULONG_PTR HighLimit);
     static const StaticDynamicallyLinkedFunctionPtr<

--- a/js/xpconnect/src/XPCJSRuntime.cpp
+++ b/js/xpconnect/src/XPCJSRuntime.cpp
@@ -777,7 +777,7 @@ void XPCJSRuntime::GCSliceCallback(JSContext* cx, JS::GCProgress progress,
   }
 
   nsCOMPtr<nsIObserverService> obs;
-  if (!recordreplay::IsRecordingOrReplaying()) {
+  if (!recordreplay::IsRecordingOrReplaying("XPCJSRuntime::GCSliceCallback")) {
     // See https://github.com/RecordReplay/backend/issues/4606
     // Do not notify observers from within GC slices, since
     // gc slices are allowed to run divergently in the replay

--- a/layout/base/PresShell.cpp
+++ b/layout/base/PresShell.cpp
@@ -5853,7 +5853,7 @@ void PresShell::DecApproximateVisibleCount(
   for (nsIFrame* frame : aFrames) {
     framesArray.AppendElement(frame);
   }
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("PresShell::DecApproximateVisibleCount")) {
     std::sort(framesArray.begin(), framesArray.end(),
               [](nsIFrame* a, nsIFrame* b) {
                 return recordreplay::ThingIndex(a) < recordreplay::ThingIndex(b);

--- a/layout/base/nsRefreshDriver.cpp
+++ b/layout/base/nsRefreshDriver.cpp
@@ -357,7 +357,7 @@ class RefreshDriverTimer {
     TickRefreshDrivers(aId, now, mContentRefreshDrivers);
     TickRefreshDrivers(aId, now, mRootRefreshDrivers);
 
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("nsRefreshDriver::Tick")) {
       recordreplay::OnPaint();
     }
 

--- a/layout/style/GlobalStyleSheetCache.cpp
+++ b/layout/style/GlobalStyleSheetCache.cpp
@@ -667,7 +667,7 @@ void GlobalStyleSheetCache::BuildPreferenceSheet(
   // The shared memory cache is disabled when recording/replaying. We can't
   // reliably ensure that fixed addresses in an area not already reserved
   // will be consistently mapped when replaying.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("GlobalStyleSheetCache::SetSharedMemory")) {
     return;
   }
 

--- a/layout/style/Loader.cpp
+++ b/layout/style/Loader.cpp
@@ -1517,7 +1517,7 @@ Loader::Completed Loader::ParseSheet(const nsACString& aBytes,
 
   // Tell the record/replay system about any sheets that are being parsed,
   // so that devtools code can find them later.
-  if (recordreplay::IsRecordingOrReplaying() && aLoadData.mURI) {
+  if (recordreplay::IsRecordingOrReplaying("Loader::ParseSheet") && aLoadData.mURI) {
     recordreplay::NoteContentParse(
         &aLoadData, aLoadData.mURI->GetSpecOrDefault().get(), "text/css",
         reinterpret_cast<const Utf8Unit*>(aBytes.BeginReading()),

--- a/mfbt/RecordReplay.cpp
+++ b/mfbt/RecordReplay.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <stdlib.h>
+#include <unordered_set>
 
 namespace mozilla {
 namespace recordreplay {
@@ -155,6 +156,50 @@ void Initialize(int* aArgc, char*** aArgv) {
 #undef INIT_SYMBOL_VOID
 
   initialize(aArgc, aArgv);
+}
+
+static const char* EXCLUDED_ISROR_ENV = "RECORD_REPLAY_EXCLUDED_ISROR";
+typedef std::unordered_set<std::string> ExcludedCheckSet;
+static ExcludedCheckSet* EXCLUDED_CHECKS = nullptr;
+static void FillExcludedChecksSet(const char* aFilename, ExcludedCheckSet* aExcluded) {
+  if (!aFilename) {
+    return;
+  }
+
+  // Treat the exclude string as a file path and read all lines
+  FILE* file = fopen(aFilename, "r");
+  if (!file) {
+    fprintf(stderr, "Could not open %s file: %s\n", EXCLUDED_ISROR_ENV, aFilename);
+    return;
+  }
+  char buf[128];
+  while (fgets(buf, 128, file)) {
+    // Zero-out any newline chars so the string terminates at end of line.
+    for (int i = 0; i < 128; i++) {
+      buf[i] = (buf[i] == '\r' || buf[i] == '\n') ? 0 : buf[i];
+    }
+    aExcluded->insert(std::string(buf));
+  }
+}
+static void InitExcludedChecks() {
+  if (EXCLUDED_CHECKS) {
+    return;
+  }
+  ExcludedCheckSet* excluded = new ExcludedCheckSet();
+  const char* excludeString = getenv(EXCLUDED_ISROR_ENV);
+  FillExcludedChecksSet(excludeString, excluded);
+  EXCLUDED_CHECKS = excluded;
+}
+
+bool InternalIsRecordingOrReplaying(const char* aLabel) {
+  if (!gIsRecordingOrReplaying) {
+    return false;
+  }
+  InitExcludedChecks();
+  if (EXCLUDED_CHECKS && EXCLUDED_CHECKS->find(aLabel) != EXCLUDED_CHECKS->end()) {
+    return false;
+  }
+  return true;
 }
 
 // Record/replay API functions can't GC, but we can't use

--- a/mfbt/RecordReplay.h
+++ b/mfbt/RecordReplay.h
@@ -387,7 +387,7 @@ bool BuildJSON(size_t aNumProperties,
 #  define MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(aName, aFormals, aActuals) \
     MFBT_API void Internal##aName aFormals;                              \
     static inline void aName aFormals {                                  \
-      if (IsRecordingOrReplaying()) {                                    \
+      if (IsRecordingOrReplaying("RecordReplayWrapper")) {               \
         Internal##aName aActuals;                                        \
       }                                                                  \
     }
@@ -396,7 +396,7 @@ bool BuildJSON(size_t aNumProperties,
                                          aFormals, aActuals)                \
     MFBT_API aReturnType Internal##aName aFormals;                          \
     static inline aReturnType aName aFormals {                              \
-      if (IsRecordingOrReplaying()) {                                       \
+      if (IsRecordingOrReplaying("RecordReplayWrapper")) {                  \
         return Internal##aName aActuals;                                    \
       }                                                                     \
       return aDefaultValue;                                                 \
@@ -453,7 +453,7 @@ MOZ_MAKE_RECORD_REPLAY_WRAPPER_VOID(AddOrderedSRWLock,
 MFBT_API void InternalRecordReplayAssert(const char* aFormat, va_list aArgs);
 
 static inline void RecordReplayAssert(const char* aFormat, ...) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplayAssert")) {
     va_list ap;
     va_start(ap, aFormat);
     InternalRecordReplayAssert(aFormat, ap);
@@ -464,7 +464,7 @@ static inline void RecordReplayAssert(const char* aFormat, ...) {
 MFBT_API void InternalPrintLog(const char* aFormat, va_list aArgs);
 
 static inline void PrintLog(const char* aFormat, ...) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplay::PrintLog")) {
     va_list ap;
     va_start(ap, aFormat);
     InternalPrintLog(aFormat, ap);
@@ -475,7 +475,7 @@ static inline void PrintLog(const char* aFormat, ...) {
 MFBT_API void InternalDiagnostic(const char* aFormat, va_list aArgs);
 
 static inline void Diagnostic(const char* aFormat, ...) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplay::Diagnostic")) {
     va_list ap;
     va_start(ap, aFormat);
     InternalDiagnostic(aFormat, ap);

--- a/mfbt/RecordReplay.h
+++ b/mfbt/RecordReplay.h
@@ -80,7 +80,10 @@ extern MFBT_DATA bool gIsReplaying;
 extern MFBT_DATA bool gIsProfiling;
 
 // Get the kind of recording/replaying process this is, if any.
-static inline bool IsRecordingOrReplaying() { return gIsRecordingOrReplaying; }
+MFBT_API bool InternalIsRecordingOrReplaying(const char* aLabel);
+static inline bool IsRecordingOrReplaying(const char* aLabel) {
+  return InternalIsRecordingOrReplaying(aLabel);
+}
 static inline bool IsRecording() { return gIsRecording; }
 static inline bool IsReplaying() { return gIsReplaying; }
 

--- a/mozglue/dllservices/LoaderObserver.cpp
+++ b/mozglue/dllservices/LoaderObserver.cpp
@@ -64,7 +64,7 @@ void LoaderObserver::OnEndDllLoad(void* aContext, NTSTATUS aNtStatus,
                                   ModuleLoadInfo&& aModuleLoadInfo) {
   // LoaderObserver functionality is suppressed for now when recording/replaying,
   // as DLL load events will not be triggered when replaying.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("LoaderObserver::OnEndDllLoad")) {
     return;
   }
 
@@ -118,7 +118,7 @@ void LoaderObserver::Forward(nt::LoaderObserver* aNext) {
 }
 
 void LoaderObserver::Forward(detail::DllServicesBase* aNext) {
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("LoaderObserver::Forward")) {
     return;
   }
 

--- a/toolkit/components/backgroundhangmonitor/BackgroundHangMonitor.cpp
+++ b/toolkit/components/backgroundhangmonitor/BackgroundHangMonitor.cpp
@@ -650,7 +650,7 @@ void BackgroundHangMonitor::Startup() {
   }
 
   // Disable when recording/replaying, as with other kinds of telemetry.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("BackgroundHangMonitor::Startup")) {
     BackgroundHangManager::sDisabled = true;
     return;
   }

--- a/toolkit/components/finalizationwitness/FinalizationWitnessService.cpp
+++ b/toolkit/components/finalizationwitness/FinalizationWitnessService.cpp
@@ -187,7 +187,7 @@ FinalizationWitnessService::Make(const char* aTopic, const char16_t* aValue,
                                  JS::MutableHandle<JS::Value> aRetval) {
   // Finalize witnesses are not created when recording or replaying, as
   // finalizations occur non-deterministically in the recording.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("FinalizationWitnessService::Make")) {
     return NS_ERROR_NOT_AVAILABLE;
   }
 

--- a/toolkit/components/telemetry/core/Telemetry.cpp
+++ b/toolkit/components/telemetry/core/Telemetry.cpp
@@ -1059,7 +1059,7 @@ TelemetryImpl::GetCanRecordBase(bool* ret) {
 
 NS_IMETHODIMP
 TelemetryImpl::SetCanRecordBase(bool canRecord) {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("TelemetryImpl::SeteCanRecordBase")) {
     return NS_OK;
   }
 #ifndef FUZZING
@@ -1088,7 +1088,7 @@ TelemetryImpl::GetCanRecordExtended(bool* ret) {
 
 NS_IMETHODIMP
 TelemetryImpl::SetCanRecordExtended(bool canRecord) {
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("TelemetryImpl::SetCanRecordExtend")) {
     return NS_OK;
   }
 #ifndef FUZZING
@@ -1141,7 +1141,7 @@ already_AddRefed<nsITelemetry> TelemetryImpl::CreateTelemetryInstance() {
       // because the resulting measurements might be biased and because
       // measurements might occur at non-deterministic points in execution
       // (e.g. garbage collections).
-      !recordreplay::IsRecordingOrReplaying()) {
+      !recordreplay::IsRecordingOrReplaying("TelemetryImpl::CreateTelemetryInstance")) {
     useTelemetry = true;
   }
 #endif

--- a/toolkit/recordreplay/JSControl.cpp
+++ b/toolkit/recordreplay/JSControl.cpp
@@ -50,7 +50,7 @@ static StaticInfallibleVector<RecordingOperation> gRecordingOperations;
 static StaticMutex gRecordingOperationsMutex;
 
 void AddRecordingOperation(const char* aKind, const char* aValue) {
-  if (!recordreplay::IsRecordingOrReplaying()) {
+  if (!recordreplay::IsRecordingOrReplaying("JSControl::AddRecordingOperation")) {
     return;
   }
 
@@ -223,24 +223,24 @@ extern "C" {
 
 MOZ_EXPORT void RecordReplayInterface_BeginContentParse(
     const void* aToken, const char* aURL, const char* aContentType) {
-  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying());
+  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying("JSControl::RecordReplayInterface_BeginContentParse"));
   MOZ_RELEASE_ASSERT(aToken);
 }
 
 MOZ_EXPORT void RecordReplayInterface_AddContentParseData8(
     const void* aToken, const Utf8Unit* aUtf8Buffer, size_t aLength) {
-  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying());
+  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying("JSControl::RecordReplayInterface_AddContentParse8"));
   MOZ_RELEASE_ASSERT(aToken);
 }
 
 MOZ_EXPORT void RecordReplayInterface_AddContentParseData16(
     const void* aToken, const char16_t* aBuffer, size_t aLength) {
-  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying());
+  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying("JSControl::RecordReplayInterface_AddContentParseData16"));
   MOZ_RELEASE_ASSERT(aToken);
 }
 
 MOZ_EXPORT void RecordReplayInterface_EndContentParse(const void* aToken) {
-  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying());
+  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying("JSControl::RecordReplayInterface_EndContentParse"));
   MOZ_RELEASE_ASSERT(aToken);
 }
 
@@ -990,7 +990,7 @@ static void PossibleBreakpointsCallback(const char* aSourceId) {
 ///////////////////////////////////////////////////////////////////////////////
 
 bool DefineRecordReplayControlObject(JSContext* aCx, JS::HandleObject object) {
-  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying());
+  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying("JSControl::DefineRecordReplayControlObject"));
 
   RootedObject staticObject(aCx, JS_NewObject(aCx, nullptr));
   if (!staticObject ||
@@ -1042,7 +1042,7 @@ void OnRepaintNeeded(const char* aWhy) {
 void OnTestCommand(const char* aString) {
   // Ignore commands to finish the current test if we aren't recording/replaying.
   if (!strcmp(aString, "RecReplaySendAsyncMessage Example__Finished") &&
-      !IsRecordingOrReplaying()) {
+      !IsRecordingOrReplaying("JSControl::OnTestCommand")) {
     return;
   }
 

--- a/toolkit/recordreplay/Network.cpp
+++ b/toolkit/recordreplay/Network.cpp
@@ -63,7 +63,7 @@ NS_IMPL_CYCLE_COLLECTING_RELEASE(ResponseRequestObserver)
 
 NS_IMETHODIMP
 ResponseRequestObserver::OnStartRequest(nsIRequest* request) {
-  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying());
+  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying("Network::ResponseRequestObserver::OnStartRequest"));
 
   nsCOMPtr<nsIIdentChannel> channel = do_QueryInterface(request);
   nsCOMPtr<nsIObserverService> obsService = mozilla::services::GetObserverService();
@@ -84,7 +84,7 @@ ResponseRequestObserver::OnStopRequest(nsIRequest* request, nsresult status) {
 }
 
 already_AddRefed<nsIStreamListener> WrapNetworkStreamListener(nsIStreamListener* listener) {
-  if (!IsRecordingOrReplaying()) {
+  if (!IsRecordingOrReplaying("Network::WrapNetworkStreamListener")) {
     return nsCOMPtr(listener).forget();
   }
 
@@ -412,7 +412,7 @@ already_AddRefed<nsIInputStream> WrapNetworkRequestBodyStream(nsIHttpChannel* aC
                                                               int64_t aLength) {
   nsCOMPtr stream(aStream);
 
-  if (!IsRecordingOrReplaying()) {
+  if (!IsRecordingOrReplaying("Network::WrapNetworkRequestBodyStream")) {
     return stream.forget();
   }
 

--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -528,7 +528,7 @@ MOZ_EXPORT void RecordReplayInterface_InternalRecordReplayAssertBytes(
 }
 
 MOZ_EXPORT void RecordReplayAssertFromC(const char* aFormat, ...) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplayAssertFromC")) {
     va_list args;
     va_start(args, aFormat);
     gAssert(aFormat, args);
@@ -687,7 +687,7 @@ MOZ_EXPORT void RecordReplayInterface_InternalAddOrderedPthreadMutex(const char*
 }
 
 MOZ_EXPORT void RecordReplayAddOrderedPthreadMutexFromC(const char* aName, pthread_mutex_t* aMutex) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplayAddOrderedPthreadMutexFromC")) {
     gAddOrderedPthreadMutex(aName, aMutex);
   }
 }
@@ -699,7 +699,7 @@ MOZ_EXPORT void RecordReplayInterface_InternalAddOrderedCriticalSection(const ch
 }
 
 MOZ_EXPORT void RecordReplayAddOrderedCriticalSectionFromC(const char* aName, PCRITICAL_SECTION aCS) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplayAddOrderedCriticalSectionFromC")) {
     gAddOrderedCriticalSection(aName, aCS);
   }
 }
@@ -827,7 +827,7 @@ bool HasCheckpoint() {
 // Note: This should be called even if we aren't recording/replaying, to report
 // cases where recording is unsupported to the UI process.
 void CreateCheckpoint() {
-  if (!IsRecordingOrReplaying()) {
+  if (!IsRecordingOrReplaying("RecordReplay::CreateCheckpoint")) {
     if (gRecordingUnsupported) {
       js::EnsureModuleInitialized();
       js::SendRecordingUnsupported(gRecordingUnsupported);
@@ -963,43 +963,43 @@ void OnLocationChange(dom::BrowserChild* aChild, nsIURI* aLocation, uint32_t aFl
 }
 
 void NewStableHashTable(const void* aTable, KeyEqualsEntryCallback aKeyEqualsEntry, void* aPrivate) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplay::NewStableHashTable")) {
     gNewStableHashTable(aTable, aKeyEqualsEntry, aPrivate);
   }
 }
 
 void MoveStableHashTable(const void* aTableSrc, const void* aTableDst) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplay::MoveStableHashTable")) {
     gMoveStableHashTable(aTableSrc, aTableDst);
   }
 }
 
 void DeleteStableHashTable(const void* aTable) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplay::DeleteStableHashTable")) {
     gDeleteStableHashTable(aTable);
   }
 }
 
 uint32_t LookupStableHashCode(const void* aTable, const void* aKey, uint32_t aUnstableHashCode,
                               bool* aFoundMatch) {
-  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying());
+  MOZ_RELEASE_ASSERT(IsRecordingOrReplaying("RecordReplay::LookupStableHashCode"));
   return gLookupStableHashCode(aTable, aKey, aUnstableHashCode, aFoundMatch);
 }
 
 void StableHashTableAddEntryForLastLookup(const void* aTable, const void* aEntry) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplay::StableHashTableAddEntryForLastLookup")) {
     gStableHashTableAddEntryForLastLookup(aTable, aEntry);
   }
 }
 
 void StableHashTableMoveEntry(const void* aTable, const void* aEntrySrc, const void* aEntryDst) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplay::StableHashTableMoveEntry")) {
     gStableHashTableMoveEntry(aTable, aEntrySrc, aEntryDst);
   }
 }
 
 void StableHashTableDeleteEntry(const void* aTable, const void* aEntry) {
-  if (IsRecordingOrReplaying()) {
+  if (IsRecordingOrReplaying("RecordReplay::StableHashTableDeleteEntry")) {
     gStableHashTableDeleteEntry(aTable, aEntry);
   }
 }

--- a/tools/profiler/core/platform.cpp
+++ b/tools/profiler/core/platform.cpp
@@ -5170,7 +5170,7 @@ void profiler_start(PowerOfTwo32 aCapacity, double aInterval,
   // and there's no reasonable justification for running gecko
   // profiler while recording or replaying.
   // See issue https://github.com/RecordReplay/gecko-dev/issues/702
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("profiler_start")) {
     return;
   }
 

--- a/widget/VsyncDispatcher.cpp
+++ b/widget/VsyncDispatcher.cpp
@@ -113,12 +113,12 @@ void CompositorVsyncDispatcher::Shutdown() {
 RefreshTimerVsyncDispatcher::RefreshTimerVsyncDispatcher(
     gfx::VsyncSource::Display* aDisplay)
     : mDisplay(aDisplay), mRefreshTimersLock("RefreshTimers lock") {
-  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying());
+  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying("RefreshTimerVsyncDispatcher::RefreshTimerVsyncDispatcher"));
   MOZ_ASSERT(NS_IsMainThread());
 }
 
 RefreshTimerVsyncDispatcher::~RefreshTimerVsyncDispatcher() {
-  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying());
+  MOZ_ASSERT(XRE_IsParentProcess() || recordreplay::IsRecordingOrReplaying("RefreshTimerVsyncDispatcher::~RefreshTimerVsyncDispatcher"));
   MOZ_ASSERT(NS_IsMainThread());
 }
 

--- a/widget/windows/GfxInfo.cpp
+++ b/widget/windows/GfxInfo.cpp
@@ -770,7 +770,7 @@ nsresult GfxInfo::Init() {
   // if found.
   // For now we skip this when recording/replaying, because the GPU won't be
   // used and because calling CreateDXGIFactory isn't supported yet.
-  if (mHasDualGPU && !recordreplay::IsRecordingOrReplaying()) {
+  if (mHasDualGPU && !recordreplay::IsRecordingOrReplaying("GfxInfo::Init")) {
     nsModuleHandle dxgiModule(LoadLibrarySystem32(L"dxgi.dll"));
     decltype(CreateDXGIFactory)* createDXGIFactory =
         (decltype(CreateDXGIFactory)*)GetProcAddress(dxgiModule,

--- a/xpcom/base/CycleCollectedJSRuntime.cpp
+++ b/xpcom/base/CycleCollectedJSRuntime.cpp
@@ -1083,7 +1083,7 @@ void CycleCollectedJSRuntime::GCSliceCallback(JSContext* aContext,
       JS::dbg::FireOnGarbageCollectionHookRequired(aContext) &&
       // GCs happen at non-deterministic points, so we can't consistently
       // inform the debugger when a GC has occurred.
-      !recordreplay::IsRecordingOrReplaying()) {
+      !recordreplay::IsRecordingOrReplaying("CycleCollectedJSRuntime::GCSliceCallback")) {
     JS::GCReason reason = aDesc.reason_;
     Unused << NS_WARN_IF(
         NS_FAILED(DebuggerOnGCRunnable::Enqueue(aContext, aDesc)) &&
@@ -1640,7 +1640,7 @@ void IncrementalFinalizeRunnable::ReleaseNow(bool aLimited) {
                "We should have at least ReleaseSliceNow to run");
     MOZ_ASSERT(mFinalizeFunctionToRun < mDeferredFinalizeFunctions.Length(),
                "No more finalizers to run?");
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("IncrementalFinalizeRunnable::ReleaseNow")) {
       aLimited = false;
     }
 

--- a/xpcom/base/MemoryMapping.cpp
+++ b/xpcom/base/MemoryMapping.cpp
@@ -108,7 +108,7 @@ using PermSet = MemoryMapping::PermSet;
 nsresult GetMemoryMappings(nsTArray<MemoryMapping>& aMappings, pid_t aPid) {
   // Disable when recording/replaying, it has caused hangs which haven't
   // been investigated.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("MemoryMapping::GetMemoryMappings")) {
     return NS_ERROR_FAILURE;
   }
 

--- a/xpcom/base/nsTraceRefcnt.cpp
+++ b/xpcom/base/nsTraceRefcnt.cpp
@@ -575,7 +575,7 @@ static void DoInitTraceLog(const char* aProcType) {
 
   // Don't trace refcounts while recording or replaying, these are not
   // required to match up between the two executions.
-  if (mozilla::recordreplay::IsRecordingOrReplaying()) {
+  if (mozilla::recordreplay::IsRecordingOrReplaying("nsTraceRefcnt::DoInitTraceLog")) {
     return;
   }
 

--- a/xpcom/ds/PLDHashTable.cpp
+++ b/xpcom/ds/PLDHashTable.cpp
@@ -491,7 +491,7 @@ PLDHashTable::ComputeKeyHash(const void* aKey) const {
 
   PLDHashNumber keyHash = mozilla::ScrambleHashCode(mOps->hashKey(aKey));
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("PLDHashTable::ComputeKeyHash")) {
     keyHash = recordreplay::LookupStableHashCode(this, aKey, keyHash, nullptr);
   }
 

--- a/xpcom/threads/IdlePeriodState.cpp
+++ b/xpcom/threads/IdlePeriodState.cpp
@@ -252,6 +252,6 @@ bool IdlePeriodState::ShouldGetIdleToken() {
          XRE_IsContentProcess() &&
          // Disable when recording/replaying, as IdleSchedulerChild uses mutable
          // shared memory which needs special handling.
-         !recordreplay::IsRecordingOrReplaying();
+         !recordreplay::IsRecordingOrReplaying("IdlePeriodState::ShouldGetIdleToken");
 }
 }  // namespace mozilla

--- a/xpcom/threads/MozPromise.h
+++ b/xpcom/threads/MozPromise.h
@@ -1157,7 +1157,7 @@ class MozPromise : public MozPromiseBase {
     // Avoid calling AssertIsDead when recording/replaying, as the point when
     // this function runs can vary between recording and replaying,
     // and AssertIsDead takes an ordered lock.
-    if (!recordreplay::IsRecordingOrReplaying()) {
+    if (!recordreplay::IsRecordingOrReplaying("~MozPromise")) {
       AssertIsDead();
     }
 

--- a/xpcom/threads/SharedThreadPool.cpp
+++ b/xpcom/threads/SharedThreadPool.cpp
@@ -159,7 +159,7 @@ NS_IMETHODIMP_(MozExternalRefCountType) SharedThreadPool::Release(void) {
 
   // When recording/replaying this destruction code runs non-deterministically.
   // Rather than forcing this to run deterministically, let the pools leak.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("SharedThreadPool::Release")) {
     return count;
   }
 

--- a/xpcom/threads/ThreadEventQueue.cpp
+++ b/xpcom/threads/ThreadEventQueue.cpp
@@ -146,7 +146,7 @@ bool ThreadEventQueue::PutEventInternal(already_AddRefed<nsIRunnable>&& aEvent,
 already_AddRefed<nsIRunnable> ThreadEventQueue::GetEvent(
     bool aMayWait, mozilla::TimeDuration* aLastEventDelay) {
   // Run any pending non-deterministic events.
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("ThreadEventQueue::GetEvent")) {
     recordreplay::AutoDisallowThreadEvents disallow;
     MutexAutoLock lock(mLockNonDeterministic);
     while (true) {

--- a/xpcom/threads/ThrottledEventQueue.cpp
+++ b/xpcom/threads/ThrottledEventQueue.cpp
@@ -214,7 +214,7 @@ class ThrottledEventQueue::Inner final : public nsISupports {
 #endif
 
     // Run any pending non-deterministic events.
-    if (recordreplay::IsRecordingOrReplaying()) {
+    if (recordreplay::IsRecordingOrReplaying("ThrottledEventQueue::ExecuteRunnable")) {
       recordreplay::AutoDisallowThreadEvents disallow;
       MutexAutoLock lock(mMutexNonDeterministic);
       while (true) {

--- a/xpcom/threads/nsThread.cpp
+++ b/xpcom/threads/nsThread.cpp
@@ -1331,7 +1331,7 @@ void NS_DispatchMemoryPressure();
 void nsThread::DoMainThreadSpecificProcessing() const {
   MOZ_ASSERT(mIsMainThread);
 
-  if (recordreplay::IsRecordingOrReplaying()) {
+  if (recordreplay::IsRecordingOrReplaying("nsThread::DoMainThreadSpecificProcessing")) {
     recordreplay::MaybeCreateCheckpoint();
   }
 


### PR DESCRIPTION
Provide a way of controlling which IsRecordingOrReplaying calls return true when recording.

Currently the mechanism exposed is an environment variable containing a path to a file that lists all the calls to be "excluded" from real handling (e.g. always return false).