### PR TITLE
Avoid calling MainThreadHandoff::WrapInterface when replaying

### DIFF
--- a/accessible/ipc/win/COMPtrTypes.cpp
+++ b/accessible/ipc/win/COMPtrTypes.cpp
@@ -47,6 +47,15 @@ IAccessibleHolder CreateHolderFromAccessible(
                                   mscom::ToInterceptorTargetPtr(iaToProxy));
   }
 
+  // Wrapping COM interfaces while replaying is not currently supported.
+  // See also HandlerProvider::ToWrappedObject. Work around this by creating a bogus
+  // IAccessible pointer.
+  if (recordreplay::IsReplaying()) {
+    ProxyUniquePtr<IAccessible> intercepted((IAccessible*)0xDEADBEEF);
+    return IAccessibleHolder(std::move(intercepted));
+  }
+  recordreplay::AutoPassThroughThreadEvents pt;
+
   ProxyUniquePtr<IAccessible> intercepted;
   HRESULT hr = MainThreadHandoff::WrapInterface(
       std::move(iaToProxy), payload,

--- a/ipc/mscom/Ptr.h
+++ b/ipc/mscom/Ptr.h
@@ -92,7 +92,13 @@ struct MTAReleaseInChildProcess {
     // current scope, we are in effect moving our strong ref into the lambda.
     void* ptr = aPtr;
     EnsureMTA::AsyncOperation(
-        [ptr]() -> void { reinterpret_cast<T*>(ptr)->Release(); });
+        [ptr]() -> void {
+          // Pointers being released might not be valid when replaying.
+          if (!recordreplay::IsReplaying()) {
+            recordreplay::AutoPassThroughThreadEvents pt;
+            reinterpret_cast<T*>(ptr)->Release();
+          }
+        });
   }
 };
 


### PR DESCRIPTION
https://linear.app/replay/issue/BAC-1944/avoid-calling-mainthreadhandoffwrapinterface-when-replaying