### PR TITLE
Tolerate worker reference releases at non-deterministic points

### DIFF
--- a/dom/workers/WorkerPrivate.cpp
+++ b/dom/workers/WorkerPrivate.cpp
@@ -1455,7 +1455,7 @@ void WorkerPrivate::Traverse(nsCycleCollectionTraversalCallback& aCb) {
 nsresult WorkerPrivate::Dispatch(already_AddRefed<WorkerRunnable> aRunnable,
                                  nsIEventTarget* aSyncLoopTarget) {
   // May be called on any thread!
-  MutexAutoLock lock(mMutex);
+  MutexAutoLockMaybeEventsDisallowed lock(mMutex);
   return DispatchLockHeld(std::move(aRunnable), aSyncLoopTarget, lock);
 }
 
@@ -4228,9 +4228,6 @@ void WorkerPrivate::PostMessageToParent(
     const Sequence<JSObject*>& aTransferable, ErrorResult& aRv) {
   AssertIsOnWorkerThread();
   MOZ_DIAGNOSTIC_ASSERT(IsDedicatedWorker());
-
-  // For issue https://github.com/RecordReplay/backend/issues/5799
-  recordreplay::RecordReplayAssert("WorkerPrivate::PostMessageToParent start");
 
   JS::Rooted<JS::Value> transferable(aCx, JS::UndefinedValue());
 

--- a/dom/workers/WorkerPrivate.cpp
+++ b/dom/workers/WorkerPrivate.cpp
@@ -1456,7 +1456,7 @@ nsresult WorkerPrivate::Dispatch(already_AddRefed<WorkerRunnable> aRunnable,
                                  nsIEventTarget* aSyncLoopTarget) {
   // May be called on any thread!
   MutexAutoLockMaybeEventsDisallowed lock(mMutex);
-  return DispatchLockHeld(std::move(aRunnable), aSyncLoopTarget, lock);
+  return DispatchLockHeld(std::move(aRunnable), aSyncLoopTarget, lock.get());
 }
 
 nsresult WorkerPrivate::DispatchLockHeld(

--- a/dom/workers/WorkerPrivate.cpp
+++ b/dom/workers/WorkerPrivate.cpp
@@ -1455,8 +1455,8 @@ void WorkerPrivate::Traverse(nsCycleCollectionTraversalCallback& aCb) {
 nsresult WorkerPrivate::Dispatch(already_AddRefed<WorkerRunnable> aRunnable,
                                  nsIEventTarget* aSyncLoopTarget) {
   // May be called on any thread!
-  MutexAutoLockMaybeEventsDisallowed lock(mMutex);
-  return DispatchLockHeld(std::move(aRunnable), aSyncLoopTarget, lock.get());
+  MutexAutoLock lock(mMutex);
+  return DispatchLockHeld(std::move(aRunnable), aSyncLoopTarget, lock);
 }
 
 nsresult WorkerPrivate::DispatchLockHeld(

--- a/dom/workers/WorkerRef.cpp
+++ b/dom/workers/WorkerRef.cpp
@@ -201,6 +201,9 @@ ThreadSafeWorkerRef::ThreadSafeWorkerRef(StrongWorkerRef* aRef) : mRef(aRef) {
 ThreadSafeWorkerRef::~ThreadSafeWorkerRef() {
   // Let's release the StrongWorkerRef on the correct thread.
   if (!mRef->mWorkerPrivate->IsOnWorkerThread()) {
+    // Worker references can be released at non-deterministic points.
+    recordreplay::AutoDisallowThreadEvents disallow;
+
     WorkerPrivate* workerPrivate = mRef->mWorkerPrivate;
     RefPtr<ReleaseRefControlRunnable> r =
         new ReleaseRefControlRunnable(workerPrivate, mRef.forget());

--- a/dom/workers/WorkerRef.cpp
+++ b/dom/workers/WorkerRef.cpp
@@ -201,8 +201,13 @@ ThreadSafeWorkerRef::ThreadSafeWorkerRef(StrongWorkerRef* aRef) : mRef(aRef) {
 ThreadSafeWorkerRef::~ThreadSafeWorkerRef() {
   // Let's release the StrongWorkerRef on the correct thread.
   if (!mRef->mWorkerPrivate->IsOnWorkerThread()) {
-    // Worker references can be released at non-deterministic points.
-    recordreplay::AutoDisallowThreadEvents disallow;
+    // Worker references can be released at non-deterministic points. Unfortunately,
+    // worker control runnables must be dispatched at deterministic points. For now
+    // we workaround this dilemma by letting the references leak.
+    if (recordreplay::IsRecordingOrReplaying()) {
+      mRef.forget();
+      return;
+    }
 
     WorkerPrivate* workerPrivate = mRef->mWorkerPrivate;
     RefPtr<ReleaseRefControlRunnable> r =

--- a/dom/workers/WorkerRunnable.cpp
+++ b/dom/workers/WorkerRunnable.cpp
@@ -51,11 +51,7 @@ WorkerRunnable::WorkerRunnable(WorkerPrivate* aWorkerPrivate,
     : mWorkerPrivate(aWorkerPrivate),
       mBehavior(aBehavior),
       mCanceled(0),
-      mCallingCancelWithinRun(false),
-      mRecordReplayAutoReg(this) {
-  // For issue https://github.com/RecordReplay/backend/issues/5799
-  recordreplay::RecordReplayAssert("WorkerRunnable::WorkerRunnable thingIdx=%u",
-    recordreplay::ThingIndex(this));
+      mCallingCancelWithinRun(false) {
   MOZ_ASSERT(aWorkerPrivate);
 }
 
@@ -96,17 +92,11 @@ bool WorkerRunnable::PreDispatch(WorkerPrivate* aWorkerPrivate) {
 }
 
 bool WorkerRunnable::Dispatch() {
-  // For issue https://github.com/RecordReplay/backend/issues/5799
-  recordreplay::RecordReplayAssert("WorkerRunnable::Dispatch PRE %u",
-          recordreplay::ThingIndex(this));
   bool ok = PreDispatch(mWorkerPrivate);
   if (ok) {
     ok = DispatchInternal();
   }
   PostDispatch(mWorkerPrivate, ok);
-  // For issue https://github.com/RecordReplay/backend/issues/5799
-  recordreplay::RecordReplayAssert("WorkerRunnable::Dispatch POST %u ok=%s",
-          recordreplay::ThingIndex(this), ok ? "yes" : "no");
   return ok;
 }
 

--- a/dom/workers/WorkerRunnable.h
+++ b/dom/workers/WorkerRunnable.h
@@ -67,9 +67,6 @@ class WorkerRunnable : public nsIRunnable, public nsICancelableRunnable {
   // thread. To be safe we're using an atomic but it's likely overkill.
   Atomic<uint32_t> mCanceled;
 
-  // For issue https://github.com/RecordReplay/backend/issues/5799
-  recordreplay::AutoRegisterThing mRecordReplayAutoReg;
-
  private:
   // Whether or not Cancel() is currently being called from inside the Run()
   // method. Avoids infinite recursion when a subclass calls Run() from inside


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-423/doctolib-runtime-crashes-aloisbridenne