### PR TITLE
Respect character encoding when fetching sourcemaps

### DIFF
--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -1476,7 +1476,7 @@ async function fetchText(contentPrincipal, recordingId, url) {
   }
 
   try {
-    const {inputStream, resultCode, statusCode} = await new Promise((resolve, reject) => {
+    const {inputStream, resultCode, statusCode, charset} = await new Promise((resolve, reject) => {
       const channel = NetUtil.newChannel({
         uri: urlObj.toString(),
         loadingPrincipal: contentPrincipal,
@@ -1498,6 +1498,7 @@ async function fetchText(contentPrincipal, recordingId, url) {
           inputStream,
           resultCode,
           statusCode,
+          charset: channel.contentCharset || undefined,
         });
       });
     });
@@ -1515,7 +1516,7 @@ async function fetchText(contentPrincipal, recordingId, url) {
       return null;
     }
 
-    const str = NetUtil.readInputStreamToString(inputStream, inputStream.available());
+    const str = NetUtil.readInputStreamToString(inputStream, inputStream.available(), { charset });
     inputStream.close();
 
     return {


### PR DESCRIPTION
Note that we could pass the `charset` in a third argument to `NetUtil.readInputStreamToString()` but all the calls of that function either use a fixed charset (usually utf-8) or do the conversion afterwards, so I wasn't sure if `NetUtil.readInputStreamToString()` accepts all possible values of `channel.contentCharset` and decided to follow the pattern I found [here](https://github.com/replayio/gecko-dev/blob/0536c2312b86f74414174443da8aaf9d035acc67/devtools/shared/webconsole/network-helper.js#L147-L148) instead.