### PR TITLE
Remove use of RecordReplaySetCrashLogFile

### DIFF
--- a/toolkit/recordreplay/ProcessRecordReplay.cpp
+++ b/toolkit/recordreplay/ProcessRecordReplay.cpp
@@ -498,13 +498,6 @@ MOZ_EXPORT void RecordReplayInterface_Initialize(int* aArgc, char*** aArgv) {
     gIsReplaying = gRecordReplayIsReplaying();
   }
 
-  const char* logFile = getenv("RECORD_REPLAY_CRASH_LOG");
-  if (logFile) {
-    void (*SetCrashLogFile)(const char*);
-    LoadSymbol("RecordReplaySetCrashLogFile", SetCrashLogFile);
-    SetCrashLogFile(logFile);
-  }
-
   void (*SetFreeCallback)(void (*aCallback)(void*));
   LoadSymbol("RecordReplaySetFreeCallback", SetFreeCallback);
   SetFreeCallback(FreeCallback);


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-499/remove-use-of-recordreplaysetcrashlogfile-from-gecko