### PR TITLE
Add recording assertions for performance.now mismatch

### DIFF
--- a/dom/performance/Performance.cpp
+++ b/dom/performance/Performance.cpp
@@ -98,6 +98,9 @@ DOMHighResTimeStamp Performance::TimeStampToDOMHighResForRendering(
 }
 
 DOMHighResTimeStamp Performance::Now() {
+  // https://linear.app/replay/issue/FE-589
+  recordreplay::AssertScriptedCaller("Performance::Now");
+
   DOMHighResTimeStamp rawTime = NowUnclamped();
 
   // XXX: Remove this would cause functions in pkcs11f.h to fail.

--- a/netwerk/protocol/http/HttpChannelChild.cpp
+++ b/netwerk/protocol/http/HttpChannelChild.cpp
@@ -91,6 +91,9 @@ HttpChannelChild::HttpChannelChild()
       mSuspendedByWaitingForPermissionCookie(false) {
   LOG(("Creating HttpChannelChild @%p\n", this));
 
+  // https://linear.app/replay/issue/FE-589
+  recordreplay::RecordReplayAssert("HttpChannelChild::HttpChannelChild");
+
   mChannelCreationTime = PR_Now();
   mChannelCreationTimestamp = TimeStamp::Now();
   mLastStatusReported =


### PR DESCRIPTION
https://linear.app/replay/issue/FE-593/add-asserts-for-performancenow-mismatch