### PR TITLE
Fix warning when adding nsPipeOutputStream ref when events are disall…

### DIFF
--- a/xpcom/io/nsPipe3.cpp
+++ b/xpcom/io/nsPipe3.cpp
@@ -1628,7 +1628,7 @@ nsPipeOutputStream::AddRef() {
   // Ensure the pipe is closed at a consistent point when replaying by only
   // modifying the refcount within an ordered lock.
   {
-    ReentrantMonitorAutoEnter mon(mPipe->mReentrantMonitor);
+    ReentrantMonitorAutoEnterMaybeEventsDisallowed mon(mPipe->mReentrantMonitor);
     ++mWriterRefCnt;
   }
   return mPipe->AddRef();


### PR DESCRIPTION
…owed

https://linear.app/replay/issue/BAC-2196

We use an ordered lock when changing the refcount on this class in order to ensure it is closed at a consistent point, but both adds and releases can occur when events are disallowed (in which case no ordering will be preserved when replaying).  I don't know how much we can really rely on the destruction happening at a consistent point, but I'm hesitant to just remove this ordering constraint and don't remember why we want the close to happen at a consistent point (in many cases like this the close can happen non-deterministically without causing problems).