### PR TITLE
Disallow events when closing pipe output stream after last reference …

### DIFF
--- a/xpcom/io/nsPipe3.cpp
+++ b/xpcom/io/nsPipe3.cpp
@@ -1632,6 +1632,9 @@ nsPipeOutputStream::AddRef() {
 NS_IMETHODIMP_(MozExternalRefCountType)
 nsPipeOutputStream::Release() {
   if (--mWriterRefCnt == 0) {
+    // Because the refcount is threadsafe, the final release can occur at
+    // non-deterministic points.
+    recordreplay::AutoDisallowThreadEvents disallow;
     Close();
   }
   return mPipe->Release();


### PR DESCRIPTION
…release

Followup to https://github.com/replayio/gecko-dev/pull/921, because we're not ordering these refcount changes anymore and the refcount is threadsafe, the last release could happen at non-deterministic points and the resulting close should disallow events.