### PR TITLE
Fix signature of Browser.setVideoRecordingOptions

### DIFF
--- a/juggler/protocol/BrowserHandler.js
+++ b/juggler/protocol/BrowserHandler.js
@@ -213,8 +213,8 @@ class BrowserHandler {
     await this._targetRegistry.browserContextForId(browserContextId).setForcedColors(nullToUndefined(forcedColors));
   }
 
-  async ['Browser.setVideoRecordingOptions']({browserContextId, dir, width, height, scale}) {
-    await this._targetRegistry.browserContextForId(browserContextId).setVideoRecordingOptions({dir, width, height, scale});
+  async ['Browser.setVideoRecordingOptions']({browserContextId, options}) {
+    await this._targetRegistry.browserContextForId(browserContextId).setVideoRecordingOptions(options);
   }
 
   async ['Browser.setUserAgentOverride']({browserContextId, userAgent}) {

--- a/juggler/protocol/Protocol.js
+++ b/juggler/protocol/Protocol.js
@@ -453,9 +453,11 @@ const Browser = {
     'setVideoRecordingOptions': {
       params: {
         browserContextId: t.Optional(t.String),
-        dir: t.String,
-        width: t.Number,
-        height: t.Number,
+        options: t.Optional({
+          dir: t.String,
+          width: t.Number,
+          height: t.Number,
+        }),
       },
     },
     'cancelDownload': {


### PR DESCRIPTION
The signature for Browser.setVideoRecordingOptions was incorrect when updated in #739 so this fixes it to match v1.19.2 in upstream playwright

https://github.com/microsoft/playwright/blob/c3a035560a0113f85c686d03a9c022d2e32b42a6/browser_patches/firefox/juggler/protocol/Protocol.js#L453-L462

https://github.com/microsoft/playwright/blob/v1.19.2/browser_patches/firefox/juggler/protocol/BrowserHandler.js#L216-L219