### PR TITLE
Improve auth token handling and telemetry

### DIFF
--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -112,7 +112,7 @@ function validateUserToken() {
     const { payload } = tokenInfo(userToken);
     const exp = tokenExpiration(userToken);
     if (exp < Date.now()) {
-      pingTelemetry("browser", "token-expired", {
+      pingTelemetry("browser", "auth-expired", {
         expiration: exp,
         authId: payload.sub
       });

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -105,6 +105,16 @@ function tokenExpiration(token) {
   return typeof exp === "number" ? exp * 1000 : null;
 }
 
+function validateUserToken() {
+  const userToken = getReplayUserToken();
+  if (userToken) {
+    const exp = tokenExpiration(userToken);
+    if (exp < Date.now()) {
+      setReplayUserToken(null);
+    }
+  }
+}
+
 // Tracks the open replay.io tabs. If one is closed, its currentWindowGlobal
 // will be set to null and will be removed from the map on the next pass
 const webChannelTargets = new Map();
@@ -261,6 +271,7 @@ Services.prefs.addObserver("devtools.recordreplay.user-token", () => {
 
 // Init
 (() => {
+  validateUserToken();
   initializeRecordingWebChannel();
   refresh();
 })();

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -215,7 +215,8 @@ async function refresh() {
       Services.prefs.setStringPref("devtools.recordreplay.refresh-token", json.refresh_token);
       setReplayUserToken(json.access_token);
 
-      setTimeout(refresh, json.expires_in * 1000);
+      // refresh a minute before token expiration
+      setTimeout(refresh, json.expires_in * 1000 - (60 * 1000));
     } else {
       pingTelemetry("browser", "auth-request-failed", {
         message: "no-access-token"

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -142,7 +142,7 @@ function notifyWebChannelTargets() {
 
 // Notify a single tab of the current auth state
 function notifyWebChannelTarget(channel, target) {
-  let token = getReplayUserToken();
+  const token = getReplayUserToken();
 
   if (validateUserToken()) {
     channel.send({ token }, target);

--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -354,57 +354,6 @@ function clearUserToken() {
 // key and ignores tokens provided by any logged-in session.
 if (ReplayAuth.hasOriginalApiKey()) {
   setAccessToken(ReplayAuth.getOriginalApiKey(), true /* isAPIKey */);
-} else {
-  let gExpirationTimer;
-
-  const ensureAccessTokenStateSynchronized = function() {
-    if (gExpirationTimer) {
-      clearTimeout(gExpirationTimer);
-      gExpirationTimer = null;
-    }
-
-    let token = ReplayAuth.getReplayUserToken();
-    if (!token) {
-      gShouldValidateUrl = null;
-      return;
-    }
-
-    const payload = ReplayAuth.tokenInfo(token);
-    const expiration = ReplayAuth.tokenExpiration(token);
-    if (typeof expiration !== "number") {
-      ChromeUtils.recordReplayLog(`InvalidJWTExpiration`);
-      clearUserToken();
-      return;
-    }
-
-    const timeToExpiration = expiration - Date.now();
-    if (timeToExpiration <= 0) {
-      pingTelemetry("browser", "auth-expired", {
-        expiration,
-        authId: payload.payload.sub,
-      });
-      clearUserToken();
-      return;
-    }
-
-    gExpirationTimer = setTimeout(
-      () => {
-        pingTelemetry("browser", "auth-expired", {
-          expiration,
-          authId: payload.payload.sub,
-        });
-        clearUserToken();
-      },
-      timeToExpiration
-    );
-
-    setAccessToken(token);
-  }
-
-  Services.prefs.addObserver("devtools.recordreplay.user-token", () => {
-    ensureAccessTokenStateSynchronized();
-  });
-  ensureAccessTokenStateSynchronized();
 }
 
 const beginRecordingResourceUpload = recordingId => {

--- a/devtools/server/actors/replay/connection.js
+++ b/devtools/server/actors/replay/connection.js
@@ -356,6 +356,12 @@ if (ReplayAuth.hasOriginalApiKey()) {
   setAccessToken(ReplayAuth.getOriginalApiKey(), true /* isAPIKey */);
 }
 
+Services.prefs.addObserver("devtools.recordreplay.user-token", () => {
+  // when the token changes (for either login or logout), reset the validate url
+  // flag to null so we check again for the potentially new user
+  gShouldValidateUrl = null;
+});
+
 const beginRecordingResourceUpload = recordingId => {
   return sendCommand("Internal.beginRecordingResourceUpload", {
     recordingId: recordingId,


### PR DESCRIPTION
Fixes SCS-159

* Remove the expiration logic from connection.js and handle it in auth.js
* Avoid sending an expired token to the client
* Refresh the auth token a bit before expiration
