### PR TITLE
Suppress warning when draining input stream with events disallowed

### DIFF
--- a/xpcom/io/nsPipe3.cpp
+++ b/xpcom/io/nsPipe3.cpp
@@ -740,7 +740,7 @@ SegmentChangeResult nsPipe::AdvanceReadSegment(
 
 void nsPipe::DrainInputStream(nsPipeReadState& aReadState,
                               nsPipeEvents& aEvents) {
-  ReentrantMonitorAutoEnter mon(mReentrantMonitor);
+  ReentrantMonitorAutoEnterMaybeEventsDisallowed mon(mReentrantMonitor);
 
   // If a segment is actively being read in ReadSegments() for this input
   // stream, then we cannot drain the stream.  This can happen because


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-682