### PR TITLE
set access token on startup

### DIFF
--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -338,6 +338,8 @@ Services.prefs.addObserver("devtools.recordreplay.user-token", () => {
 // Init
 (() => {
   initializeRecordingWebChannel();
-  captureLastAuthId();
-  validateUserToken();
+  if (!hasOriginalApiKey()) {
+    captureLastAuthId();
+    setReplayUserToken(validateUserToken());
+  }
 })();


### PR DESCRIPTION
* Only capture and validate tokens if not using an API key
* When not using an API key, set the user token after validating to trigger `setAccessToken` in `connection.js`