### PR TITLE
Ensure user token is passed to listeners

### DIFF
--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -72,6 +72,9 @@ function setReplayRefreshToken(token) {
   Services.prefs.setStringPref("devtools.recordreplay.refresh-token", token || "");
 }
 
+/**
+ * @param {string | null} token
+ */
 function setReplayUserToken(token) {
   token = token || "";
 
@@ -142,6 +145,9 @@ function scheduleRefreshTimer(expiresInMs) {
   refreshTimer = setTimeout(refresh, expiresInMs - (60 * 1000));
 }
 
+/**
+ * @returns {Promise<string | null>}
+ */
 async function validateUserToken() {
   const userToken = getReplayUserToken();
 
@@ -336,10 +342,13 @@ Services.prefs.addObserver("devtools.recordreplay.user-token", () => {
 });
 
 // Init
-(() => {
+(async () => {
   initializeRecordingWebChannel();
   if (!hasOriginalApiKey()) {
     captureLastAuthId();
-    setReplayUserToken(validateUserToken());
+    // clear the token so we ensure that the token is communicated to connection.js
+    const token = await validateUserToken();
+    setReplayUserToken(null);
+    setReplayUserToken(token);
   }
 })();

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -338,6 +338,8 @@ Services.prefs.addObserver("devtools.recordreplay.user-token", () => {
 // Init
 (() => {
   initializeRecordingWebChannel();
-  captureLastAuthId();
-  validateUserToken();
+  if (!hasOriginalApiKey()) {
+    captureLastAuthId();
+    setReplayUserToken(validateUserToken());
+  }
 })();


### PR DESCRIPTION
* `await` the token validation to get the token value
* Clear the token before setting it to ensure that listeners are notified

## Note

I think we'll want to continue to refactor all the auth logic into this module incl moving the API key conditions and decouple from the pref notification to avoid this clear-then-set logic but I want to unbreak auth asap