### PR TITLE
Add generic annotation hook

### DIFF
--- a/devtools/server/actors/replay/annotations/contentScript.js
+++ b/devtools/server/actors/replay/annotations/contentScript.js
@@ -11,11 +11,13 @@ function initialize(dbgWindow, RecordReplayControl) {
   window.wrappedJSObject.__RECORD_REPLAY_ANNOTATION_HOOK__ =
     (source, message) => {
       if (!source || typeof source !== "string") {
-        throw new Error("Replay annotations must include a source");
+        window.console.error("Replay annotations must include a source");
+        return false;
       }
 
       if (message && typeof message !== "object") {
-        throw new Error("Replay annotation messages must be an object if set");
+        window.console.error("Replay annotation messages must be an object if set");
+        return false;
       }
 
       RecordReplayControl.onAnnotation(
@@ -25,6 +27,8 @@ function initialize(dbgWindow, RecordReplayControl) {
           message
         })
       );
+
+      return true;
     };
 }
 

--- a/devtools/server/actors/replay/annotations/contentScript.js
+++ b/devtools/server/actors/replay/annotations/contentScript.js
@@ -11,12 +11,12 @@ function initialize(dbgWindow, RecordReplayControl) {
   window.wrappedJSObject.__RECORD_REPLAY_ANNOTATION_HOOK__ =
     (source, message) => {
       if (!source || typeof source !== "string") {
-        window.console.error("Replay annotations must include a source");
+        window.console.error("Replay annotations source must be a string");
         return false;
       }
 
       if (message && typeof message !== "object") {
-        window.console.error("Replay annotation messages must be an object if set");
+        window.console.error("Replay annotation message must be an object if set");
         return false;
       }
 

--- a/devtools/server/actors/replay/annotations/contentScript.js
+++ b/devtools/server/actors/replay/annotations/contentScript.js
@@ -9,21 +9,15 @@ function initialize(dbgWindow, RecordReplayControl) {
   window = dbgWindow.unsafeDereference();
 
   window.wrappedJSObject.__RECORD_REPLAY_ANNOTATION_HOOK__ =
-    (source, message) => {
-      if (!source || typeof source !== "string") {
-        window.console.error("Replay annotations source must be a string");
-        return false;
-      }
-
-      if (message && typeof message !== "object") {
-        window.console.error("Replay annotation message must be an object if set");
+    (kind, message) => {
+      if (!kind || typeof kind !== "string") {
+        window.console.error("Replay annotation `kind` must be a string");
         return false;
       }
 
       RecordReplayControl.onAnnotation(
-        "generic",
+        kind,
         JSON.stringify({
-          source,
           message
         })
       );

--- a/devtools/server/actors/replay/annotations/contentScript.js
+++ b/devtools/server/actors/replay/annotations/contentScript.js
@@ -10,8 +10,16 @@ function initialize(dbgWindow, RecordReplayControl) {
 
   window.wrappedJSObject.__RECORD_REPLAY_ANNOTATION_HOOK__ =
     (source, message) => {
+      if (!source || typeof source !== "string") {
+        throw new Error("Replay annotations must include a source");
+      }
+
+      if (message && typeof message !== "object") {
+        throw new Error("Replay annotation messages must be an object if set");
+      }
+
       RecordReplayControl.onAnnotation(
-        "generic-annotation",
+        "generic",
         JSON.stringify({
           source,
           message

--- a/devtools/server/actors/replay/annotations/contentScript.js
+++ b/devtools/server/actors/replay/annotations/contentScript.js
@@ -1,0 +1,23 @@
+/* global chrome */
+
+'use strict';
+
+let window;
+
+
+function initialize(dbgWindow, RecordReplayControl) {
+  window = dbgWindow.unsafeDereference();
+
+  window.wrappedJSObject.__RECORD_REPLAY_ANNOTATION_HOOK__ =
+    (source, message) => {
+      RecordReplayControl.onAnnotation(
+        "generic-annotation",
+        JSON.stringify({
+          source,
+          message
+        })
+      );
+    };
+}
+
+exports.initialize = initialize;

--- a/devtools/server/actors/replay/annotations/moz.build
+++ b/devtools/server/actors/replay/annotations/moz.build
@@ -1,0 +1,3 @@
+DevToolsModules(
+    "contentScript.js",
+)

--- a/devtools/server/actors/replay/module.js
+++ b/devtools/server/actors/replay/module.js
@@ -64,6 +64,10 @@ const {
   initialize: initReduxDevtools,
 } = require("devtools/server/actors/replay/redux-devtools/contentScript");
 
+const {
+  initialize: initGenericAnnotations,
+} = require("devtools/server/actors/replay/annotations/contentScript");
+
 const { evalExpression } = ChromeUtils.import("resource://devtools/server/actors/replay/pure-eval-dbg.jsm");
 
 const { StackingContext } = require("devtools/server/actors/replay/stacking-context");
@@ -508,6 +512,8 @@ gNewGlobalHooks.push(dbgWindow => {
         && !getenv("RECORD_REPLAY_DISABLE_REDUX_DEVTOOLS")) {
       initReduxDevtools(dbgWindow, RecordReplayControl);
     }
+
+    initGenericAnnotations(dbgWindow, RecordReplayControl);
   }
 });
 

--- a/devtools/server/actors/replay/moz.build
+++ b/devtools/server/actors/replay/moz.build
@@ -6,7 +6,8 @@
 
 DIRS += [
     "react-devtools",
-    "redux-devtools"
+    "redux-devtools",
+    "annotations"
 ]
 
 DevToolsModules(


### PR DESCRIPTION
Adds the global fn, `__RECORD_REPLAY_ANNOTATION_HOOK__`, when recording to allow userland scripts to add their own annotations.