### PR TITLE
Bail on token validation for invalid tokens

### DIFF
--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -150,8 +150,9 @@ function scheduleRefreshTimer(expiresInMs) {
  */
 async function validateUserToken() {
   const userToken = getReplayUserToken();
+  const userTokenInfo = tokenInfo(userToken);
 
-  if (!userToken) {
+  if (!userToken || !userTokenInfo) {
     return null;
   }
 
@@ -167,12 +168,10 @@ async function validateUserToken() {
   const refreshedToken = await refresh();
 
   if (!refreshedToken) {
-    const t = tokenInfo(userToken);
-
     pingTelemetry("browser", "auth-expired", {
       expirationDate: new Date(exp).toISOString(),
       expiration: exp,
-      authId: t?.payload.sub
+      authId: userTokenInfo.payload.sub
     });
   }
 


### PR DESCRIPTION
If the token stored in the pref is invalid, we still try to refresh and fail logging an `auth-expired` event. This seems to only happen for one of our test machines that must have an invalid pref value.