### PR TITLE
Message user on auth error

### DIFF
--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1487,7 +1487,7 @@ function pickSigninPage(gBrowser) {
   const externalAuthFlow = Services.prefs.getBoolPref("devtools.recordreplay.ext-auth", false);
 
   if (externalAuthFlow) {
-    openSigninPage();
+    openSigninPage(gBrowser.selectedBrowser);
     return;
   }
 


### PR DESCRIPTION
* Message user via notification on auth error
* Send `clientKey` to honeycomb on auth error so we can correlate issues with the DB

<img width="606" alt="image" src="https://user-images.githubusercontent.com/788456/199859809-bedac782-fc24-4219-aac2-39818eab9f18.png">

