### PR TITLE
Route auth refresh errors through user messaging

### DIFF
--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1487,7 +1487,7 @@ function pickSigninPage(gBrowser) {
   const externalAuthFlow = Services.prefs.getBoolPref("devtools.recordreplay.ext-auth", false);
 
   if (externalAuthFlow) {
-    openSigninPage(gBrowser.selectedBrowser);
+    openSigninPage();
     return;
   }
 

--- a/devtools/startup/DevToolsStartup.jsm
+++ b/devtools/startup/DevToolsStartup.jsm
@@ -1487,7 +1487,7 @@ function pickSigninPage(gBrowser) {
   const externalAuthFlow = Services.prefs.getBoolPref("devtools.recordreplay.ext-auth", false);
 
   if (externalAuthFlow) {
-    openSigninPage();
+    openSigninPage(gBrowser.selectedBrowser);
     return;
   }
 


### PR DESCRIPTION
Errors that came from exchanging the refresh token for an access token were logged to telemetry but not messaged to the user. The proposed fix refactors the notification logic so it can be called by both sites.