### PR TITLE
Suppress auth headers when closing auth request

### DIFF
--- a/devtools/server/actors/replay/api-server.js
+++ b/devtools/server/actors/replay/api-server.js
@@ -25,8 +25,8 @@ function getAPIServer() {
   return Services.prefs.getStringPref("devtools.recordreplay.apiServer");
 }
 
-async function queryAPIServer(query, variables = {}) {
-  const token = ReplayAuth.getReplayUserToken() || ReplayAuth.getOriginalApiKey();
+async function queryAPIServer(query, variables = {}, anonymous = false) {
+  const token = anonymous ? null : (ReplayAuth.getReplayUserToken() || ReplayAuth.getOriginalApiKey());
 
   const headers = {
     "Content-Type": "application/json",

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -381,7 +381,7 @@ function openSigninPage() {
             }
           `, {
             key
-          });
+          }, true);
 
           if (resp.errors) {
             if (resp.errors.length === 1 && resp.errors[0].message === "Authentication request does not exist") {


### PR DESCRIPTION
We had a case this week where `closeAuthRequest` failed because the request included an expired JWT. This endpoint is supposed to be anonymous so we shouldn't try to send an auth header for it.