### PR TITLE
Narrowing asserts in VideoOutput and VideoFrameContainer

### DIFF
--- a/dom/media/VideoFrameContainer.cpp
+++ b/dom/media/VideoFrameContainer.cpp
@@ -132,6 +132,7 @@ void VideoFrameContainer::SetCurrentFramesLocked(
     const gfx::IntSize& aIntrinsicSize,
     const nsTArray<ImageContainer::NonOwningImage>& aImages) {
   mMutex.AssertCurrentThreadOwns();
+  recordreplay::RecordReplayAssert("[RUN-1253] VideoFrameContainer::SetCurrentFramesLocked #1");
 
   if (aIntrinsicSize != mIntrinsicSize) {
     mIntrinsicSize = aIntrinsicSize;
@@ -153,6 +154,8 @@ void VideoFrameContainer::SetCurrentFramesLocked(
   //  until it is safe.
   nsTArray<ImageContainer::OwningImage> oldImages;
   mImageContainer->GetCurrentImages(&oldImages);
+  recordreplay::RecordReplayAssert("[RUN-1253] VideoFrameContainer::SetCurrentFramesLocked #2 %u",
+    (unsigned) oldImages.Length());
 
   PrincipalHandle principalHandle = PRINCIPAL_HANDLE_NONE;
   ImageContainer::FrameID lastFrameIDForOldPrincipalHandle =
@@ -173,6 +176,8 @@ void VideoFrameContainer::SetCurrentFramesLocked(
     mFrameIDForPendingPrincipalHandle = 0;
   }
 
+  recordreplay::RecordReplayAssert("[RUN-1253] VideoFrameContainer::SetCurrentFramesLocked #3 %u",
+    (unsigned) aImages.IsEmpty());
   if (aImages.IsEmpty()) {
     mImageContainer->ClearAllImages();
   } else {

--- a/dom/media/VideoOutput.h
+++ b/dom/media/VideoOutput.h
@@ -118,8 +118,10 @@ class VideoOutput : public DirectMediaTrackListener {
           lastPrincipalHandle, images.LastElement().mFrameID);
     }
 
+    recordreplay::RecordReplayAssert("[RUN-1253] VideoOutput::SendFrames #1");
     mVideoFrameContainer->SetCurrentFrames(
         mFrames[0].second.mFrame.GetIntrinsicSize(), images);
+    recordreplay::RecordReplayAssert("[RUN-1253] VideoOutput::SendFrames #2");
     mMainThread->Dispatch(NewRunnableMethod("VideoFrameContainer::Invalidate",
                                             mVideoFrameContainer,
                                             &VideoFrameContainer::Invalidate));


### PR DESCRIPTION
For #RUN-1319 (https://linear.app/replay/issue/RUN-1319/narrowing-asserts-in-gecko-videooutput-and-videoframecontainer)