### PR TITLE
Assert mTopLevelManager in IProtocol::SetManager.

### DIFF
--- a/ipc/glue/ProtocolUtils.cpp
+++ b/ipc/glue/ProtocolUtils.cpp
@@ -495,6 +495,9 @@ bool IProtocol::DeallocShmem(Shmem& aMem) {
 
 void IProtocol::SetManager(IProtocol* aManager) {
   MOZ_RELEASE_ASSERT(!mManager || mManager == aManager);
+  recordreplay::RecordReplayAssert("[RUN-916] IProtocol::SetManager %d %d",
+    (int) !!mManager,
+    (int) !!aManager->mToplevel);
   mManager = aManager;
   mToplevel = aManager->mToplevel;
 }


### PR DESCRIPTION
For #RUN-1320 (https://linear.app/replay/issue/RUN-1320/assert-mtoplevel-within-iprotocolsetmanager)