### PR TITLE
Fix fetching playwright branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
           authkey: ${{ secrets.TAILSCALE_API_KEY }}
           version: "1.38.4"
       - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git fetch --no-tags --depth=1 origin webreplay-release
+          git fetch --no-tags --depth=1 origin replay-playwright
       - uses: ./.github/actions/release
         env:
           BUILD_TEST_AUTHORIZATION: ${{ secrets.BUILD_TEST_AUTHORIZATION }}


### PR DESCRIPTION
## Issue

I removed `ref` param from `action/checkout` because it broke testing the actions from branch but that change broke the release process which needs to be able to get the latest ref from both branches to release latest.

## Resolution

`git fetch` a shallow copy of the main release branches as well so the action can run from either the primary branch or a feature branch.