### PR TITLE
Add wildcard support to webchannels

### DIFF
--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -233,11 +233,12 @@ function initializeRecordingWebChannel() {
   );
   const localUrl = "http://localhost:8080/";
 
+  registerWebChannel(/^https:\/\/.+.replay.io$/);
   registerWebChannel(pageUrl);
   registerWebChannel(localUrl);
 
   function registerWebChannel(url) {
-    const urlForWebChannel = Services.io.newURI(url);
+    const urlForWebChannel = url instanceof RegExp ? url : Services.io.newURI(url);
     const channel = new WebChannel("record-replay-token", urlForWebChannel);
 
     channel.listen((...args) => handleAuthChannelMessage(channel, ...args));

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -233,7 +233,10 @@ function initializeRecordingWebChannel() {
   );
   const localUrl = "http://localhost:8080/";
 
+  // custom subdomains
   registerWebChannel(/^https:\/\/.+.replay.io$/);
+  // preview branches
+  registerWebChannel(/^https:\/\/.+-recordreplay.vercel.app$/);
   registerWebChannel(pageUrl);
   registerWebChannel(localUrl);
 

--- a/toolkit/modules/WebChannel.jsm
+++ b/toolkit/modules/WebChannel.jsm
@@ -119,6 +119,10 @@ var WebChannel = function(id, originOrPermission) {
     // restrict based on the site's origin, not on other origin attributes
     // such as containers or private browsing.
     this._originCheckCallback = requestPrincipal => {
+      if (originOrPermission instanceof RegExp) {
+        return originOrPermission.test(requestPrincipal.originNoSuffix);
+      }
+
       return originOrPermission.prePath === requestPrincipal.originNoSuffix;
     };
   }


### PR DESCRIPTION
Adds support for wildcard URIs for WebChannels so we can forward auth to custom sub-domains of replay.io (like `legacy.replay.io`)