### PR TITLE
Fix opening two signin windows from WebChannel connection

### DIFF
--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -233,11 +233,15 @@ function initializeRecordingWebChannel() {
   );
   const localUrl = "http://localhost:8080/";
 
+  const replayio = /^https:\/\/.+.replay.io$/;
+  const previewBranches = /^https:\/\/.+-recordreplay.vercel.app$/;
   // custom subdomains
-  registerWebChannel(/^https:\/\/.+.replay.io$/);
+  registerWebChannel(replayio);
   // preview branches
-  registerWebChannel(/^https:\/\/.+-recordreplay.vercel.app$/);
-  registerWebChannel(pageUrl);
+  registerWebChannel(previewBranches);
+  if (!replayio.test(pageUrl) && !previewBranches.test(pageUrl)) {
+    registerWebChannel(pageUrl);
+  }
   registerWebChannel(localUrl);
 
   function registerWebChannel(url) {

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -240,11 +240,13 @@ function initializeRecordingWebChannel() {
   // preview branches
   registerWebChannel(previewBranches);
   if (!replayio.test(pageUrl) && !previewBranches.test(pageUrl)) {
+    console.log(pageUrl, replayio, previewBranches);
     registerWebChannel(pageUrl);
   }
   registerWebChannel(localUrl);
 
   function registerWebChannel(url) {
+    console.log("Registering WebChannel for", url);
     const urlForWebChannel = url instanceof RegExp ? url : Services.io.newURI(url);
     const channel = new WebChannel("record-replay-token", urlForWebChannel);
 

--- a/devtools/server/actors/replay/auth.js
+++ b/devtools/server/actors/replay/auth.js
@@ -233,8 +233,8 @@ function initializeRecordingWebChannel() {
   );
   const localUrl = "http://localhost:8080/";
 
-  const replayio = /^https:\/\/.+.replay.io$/;
-  const previewBranches = /^https:\/\/.+-recordreplay.vercel.app$/;
+  const replayio = /^https:\/\/.+.replay.io\/?$/;
+  const previewBranches = /^https:\/\/.+-recordreplay.vercel.app\/?$/;
   // custom subdomains
   registerWebChannel(replayio);
   // preview branches


### PR DESCRIPTION
After #978 , we were adding two WebChannel listeners on `app.replay.io` causing two windows to be opened when using the app.replay.io sign in button. Only one of the two windows would work for sign in so sometimes the user would click the right one and sometimes not.

The solution is to prevent adding a second listener when the `devtools.recordreplay.recordingsUrl` preference matches either of the regex domains.